### PR TITLE
Fix typo in scripts/CMakeLists.txt

### DIFF
--- a/src/server/scripts/CMakeLists.txt
+++ b/src/server/scripts/CMakeLists.txt
@@ -207,7 +207,7 @@ target_link_libraries(scripts
   PRIVATE
     trinity-core-interface
   PUBLIC
-    game)
+    game-interface)
 
 target_include_directories(scripts
   PUBLIC


### PR DESCRIPTION
Scripts was incorrectly linked to "game" instead of "game-interface". This fixes that typo and allows the scripts solution to compile alongside game solution, instead of being depended on game to finish first.

This is the same behavior on TC master: https://github.com/TrinityCore/TrinityCore/blob/cf0e2336895eb410857755a62550b148f7df58da/src/server/scripts/CMakeLists.txt#L215