### PR TITLE
Scripts/IcecrownCitadel: Strip out code related to raid weeklies and …

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
@@ -187,7 +187,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                 DoCast(me, SPELL_FRENZIED_BLOODTHIRST_VISUAL, true);
             }
 
-            void JustDied(Unit* killer) override
+            void JustDied(Unit* /*killer*/) override
             {
                 _JustDied();
                 Talk(SAY_DEATH);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
@@ -68,7 +68,6 @@ enum Spells
     SPELL_TWILIGHT_BLOODBOLT                = 71446,
     SPELL_INCITE_TERROR                     = 73070,
     SPELL_BLOODBOLT_WHIRL                   = 71772,
-    SPELL_ANNIHILATE                        = 71322,
 
     // Blood Infusion
     SPELL_BLOOD_INFUSION_CREDIT             = 72934
@@ -123,12 +122,10 @@ enum Points
     POINT_CENTER    = 1,
     POINT_AIR       = 2,
     POINT_GROUND    = 3,
-    POINT_MINCHAR   = 4,
 };
 
 Position const centerPos  = {4595.7090f, 2769.4190f, 400.6368f, 0.000000f};
 Position const airPos     = {4595.7090f, 2769.4190f, 422.3893f, 0.000000f};
-Position const mincharPos = {4629.3711f, 2782.6089f, 424.6390f, 0.000000f};
 
 bool IsVampire(Unit const* unit)
 {
@@ -153,8 +150,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
             void Initialize()
             {
                 _offtankGUID.Clear();
-                _creditBloodQuickening = false;
-                _killMinchar = false;
             }
 
             void Reset() override
@@ -190,7 +185,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
 
                 DoCast(me, SPELL_SHROUD_OF_SORROW, true);
                 DoCast(me, SPELL_FRENZIED_BLOODTHIRST_VISUAL, true);
-                _creditBloodQuickening = instance->GetData(DATA_BLOOD_QUICKENING_STATE) == IN_PROGRESS;
             }
 
             void JustDied(Unit* killer) override
@@ -202,25 +196,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
                     DoCastAOE(SPELL_BLOOD_INFUSION_CREDIT, true);
 
                 CleanAuras();
-
-                if (!killer)
-                    return;
-
-                // Blah, credit the quest
-                if (_creditBloodQuickening)
-                {
-                    instance->SetData(DATA_BLOOD_QUICKENING_STATE, DONE);
-                    if (Player* player = killer->ToPlayer())
-                        player->RewardPlayerAndGroupAtEvent(Is25ManRaid() ? NPC_INFILTRATOR_MINCHAR_BQ_25 : NPC_INFILTRATOR_MINCHAR_BQ, player);
-                    if (Creature* minchar = me->FindNearestCreature(NPC_INFILTRATOR_MINCHAR_BQ, 200.0f))
-                    {
-                        minchar->SetUInt32Value(UNIT_NPC_EMOTESTATE, 0);
-                        minchar->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND);
-                        minchar->SetCanFly(false);
-                        minchar->RemoveAllAuras();
-                        minchar->GetMotionMaster()->MoveCharge(4629.3711f, 2782.6089f, 401.5301f, SPEED_CHARGE / 3.0f);
-                    }
-                }
             }
 
             void CleanAuras()
@@ -237,40 +212,15 @@ class boss_blood_queen_lana_thel : public CreatureScript
                 instance->DoRemoveAurasDueToSpellOnPlayers(PRESENCE_OF_THE_DARKFALLEN);
             }
 
-            void DoAction(int32 action) override
-            {
-                if (action != ACTION_KILL_MINCHAR)
-                    return;
-
-                if (instance->GetBossState(DATA_BLOOD_QUEEN_LANA_THEL) == IN_PROGRESS)
-                    _killMinchar = true;
-                else
-                {
-                    me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND);
-                    me->GetMotionMaster()->MovePoint(POINT_MINCHAR, mincharPos);
-                }
-            }
-
             void EnterEvadeMode(EvadeReason why) override
             {
                 if (!_EnterEvadeMode(why))
                     return;
 
                 CleanAuras();
-                if (_killMinchar)
-                {
-                    _killMinchar = false;
-                    me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND);
-                    me->GetMotionMaster()->MovePoint(POINT_MINCHAR, mincharPos);
-                }
-                else
-                {
-                    me->AddUnitState(UNIT_STATE_EVADE);
-                    me->GetMotionMaster()->MoveTargetedHome();
-                    Reset();
-                }
+                me->AddUnitState(UNIT_STATE_EVADE);
+                me->GetMotionMaster()->MoveTargetedHome();
+                Reset();
             }
 
             void JustReachedHome() override
@@ -331,12 +281,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
                         if (Unit* victim = me->SelectVictim())
                             AttackStart(victim);
                         events.ScheduleEvent(EVENT_BLOOD_MIRROR, 2500, EVENT_GROUP_CANCELLABLE);
-                        break;
-                    case POINT_MINCHAR:
-                        DoCast(me, SPELL_ANNIHILATE, true);
-                        // already in evade mode
-                        me->GetMotionMaster()->MoveTargetedHome();
-                        Reset();
                         break;
                     default:
                         break;
@@ -519,8 +463,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
             GuidSet _vampires;
             GuidSet _bloodboltedPlayers;
             ObjectGuid _offtankGUID;
-            bool _creditBloodQuickening;
-            bool _killMinchar;
         };
 
         CreatureAI* GetAI(Creature* creature) const override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_festergut.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_festergut.cpp
@@ -459,24 +459,6 @@ class spell_festergut_blighted_spores : public SpellScriptLoader
                 if (InstanceScript* instance = GetTarget()->GetInstanceScript())
                     if (Creature* festergut = ObjectAccessor::GetCreature(*GetTarget(), instance->GetGuidData(DATA_FESTERGUT)))
                         festergut->AI()->SetData(DATA_INOCULATED_STACK, GetStackAmount());
-
-                HandleResidue();
-            }
-
-            void HandleResidue()
-            {
-                Player* target = GetUnitOwner()->ToPlayer();
-                if (!target)
-                    return;
-
-                if (target->HasAura(SPELL_ORANGE_BLIGHT_RESIDUE))
-                    return;
-
-                uint32 questId = target->GetMap()->Is25ManRaid() ? QUEST_RESIDUE_RENDEZVOUS_25 : QUEST_RESIDUE_RENDEZVOUS_10;
-                if (target->GetQuestStatus(questId) != QUEST_STATUS_INCOMPLETE)
-                    return;
-
-                target->CastSpell(target, SPELL_ORANGE_BLIGHT_RESIDUE, TRIGGERED_FULL_MASK);
             }
 
             void Register() override

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
@@ -301,7 +301,7 @@ class boss_lady_deathwhisper : public CreatureScript
                 instance->SetBossState(DATA_LADY_DEATHWHISPER, IN_PROGRESS);
             }
 
-            void JustDied(Unit* killer) override
+            void JustDied(Unit* /*killer*/) override
             {
                 Talk(SAY_DEATH);
 

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_lady_deathwhisper.cpp
@@ -48,10 +48,6 @@ enum ScriptTexts
     SAY_KILL                    = 14,
     SAY_BERSERK                 = 15,
     SAY_DEATH                   = 16,
-
-    // Darnavan
-    SAY_DARNAVAN_AGGRO          = 0,
-    SAY_DARNAVAN_RESCUED        = 1,
 };
 
 enum Spells
@@ -111,14 +107,6 @@ enum Spells
     SPELL_VENGEFUL_BLAST_25N          = 72010,
     SPELL_VENGEFUL_BLAST_10H          = 72011,
     SPELL_VENGEFUL_BLAST_25H          = 72012,
-
-    // Darnavan
-    SPELL_BLADESTORM                  = 65947,
-    SPELL_CHARGE                      = 65927,
-    SPELL_INTIMIDATING_SHOUT          = 65930,
-    SPELL_MORTAL_STRIKE               = 65926,
-    SPELL_SHATTERING_THROW            = 65940,
-    SPELL_SUNDER_ARMOR                = 65936,
 };
 
 enum EventTypes
@@ -147,25 +135,10 @@ enum Groups
     GROUP_TWO                = 2
 };
 
-enum DeprogrammingData
-{
-    NPC_DARNAVAN_10         = 38472,
-    NPC_DARNAVAN_25         = 38485,
-    NPC_DARNAVAN_CREDIT_10  = 39091,
-    NPC_DARNAVAN_CREDIT_25  = 39092,
-
-    ACTION_COMPLETE_QUEST   = -384720,
-    POINT_DESPAWN           = 384721,
-};
-
 enum Actions
 {
     ACTION_START_INTRO
 };
-
-#define NPC_DARNAVAN        RAID_MODE<uint32>(NPC_DARNAVAN_10, NPC_DARNAVAN_25, NPC_DARNAVAN_10, NPC_DARNAVAN_25)
-#define NPC_DARNAVAN_CREDIT RAID_MODE<uint32>(NPC_DARNAVAN_CREDIT_10, NPC_DARNAVAN_CREDIT_25, NPC_DARNAVAN_CREDIT_10, NPC_DARNAVAN_CREDIT_25)
-#define QUEST_DEPROGRAMMING RAID_MODE<uint32>(QUEST_DEPROGRAMMING_10, QUEST_DEPROGRAMMING_25, QUEST_DEPROGRAMMING_10, QUEST_DEPROGRAMMING_25)
 
 uint32 const SummonEntries[2] = {NPC_CULT_FANATIC, NPC_CULT_ADHERENT};
 
@@ -178,21 +151,6 @@ Position const SummonPositions[7] =
     {-598.9688f, 2269.264f, 51.01529f, 4.590216f}, // 5 Right Door 2 (Cult Fanatic)
     {-619.4323f, 2268.523f, 51.01530f, 4.590216f}, // 6 Right Door 3 (Cult Adherent)
     {-524.2480f, 2211.920f, 62.90960f, 3.141592f}, // 7 Upper (Random Cultist)
-};
-
-class DarnavanMoveEvent : public BasicEvent
-{
-    public:
-        DarnavanMoveEvent(Creature& darnavan) : _darnavan(darnavan) { }
-
-        bool Execute(uint64 /*time*/, uint32 /*diff*/) override
-        {
-            _darnavan.GetMotionMaster()->MovePoint(POINT_DESPAWN, SummonPositions[6]);
-            return true;
-        }
-
-    private:
-        Creature& _darnavan;
 };
 
 class boss_lady_deathwhisper : public CreatureScript
@@ -357,35 +315,6 @@ class boss_lady_deathwhisper : public CreatureScript
                 if (livingAddEntries.size() >= 5)
                     instance->DoUpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET, SPELL_FULL_HOUSE, 0, me);
 
-                if (Creature* darnavan = ObjectAccessor::GetCreature(*me, _darnavanGUID))
-                {
-                    if (darnavan->IsAlive())
-                    {
-                        darnavan->SetFaction(FACTION_FRIENDLY);
-                        darnavan->CombatStop(true);
-                        darnavan->GetMotionMaster()->MoveIdle();
-                        darnavan->SetReactState(REACT_PASSIVE);
-                        darnavan->m_Events.AddEvent(new DarnavanMoveEvent(*darnavan), darnavan->m_Events.CalculateTime(10000));
-                        darnavan->AI()->Talk(SAY_DARNAVAN_RESCUED);
-
-                        if (!killer)
-                            return;
-
-                        if (Player* owner = killer->GetCharmerOrOwnerPlayerOrPlayerItself())
-                        {
-                            if (Group* group = owner->GetGroup())
-                            {
-                                for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
-                                    if (Player* member = itr->GetSource())
-                                        if (member->IsInMap(owner))
-                                            member->KilledMonsterCredit(NPC_DARNAVAN_CREDIT);
-                            }
-                            else
-                                owner->KilledMonsterCredit(NPC_DARNAVAN_CREDIT);
-                        }
-                    }
-                }
-
                 _JustDied();
             }
 
@@ -467,11 +396,6 @@ class boss_lady_deathwhisper : public CreatureScript
             {
                 switch (summon->GetEntry())
                 {
-                    case NPC_DARNAVAN_10:
-                    case NPC_DARNAVAN_25:
-                        _darnavanGUID = summon->GetGUID();
-                        summon->AI()->AttackStart(SelectTarget(SELECT_TARGET_RANDOM));
-                        return;
                     case NPC_VENGEFUL_SHADE:
                         if (_nextVengefulShadeTargetGUID.empty())
                             break;
@@ -508,12 +432,7 @@ class boss_lady_deathwhisper : public CreatureScript
                 uint8 addIndex = _waveCounter & 1;
                 uint8 addIndexOther = uint8(addIndex ^ 1);
 
-                // Summon first add, replace it with Darnavan if weekly quest is active
-                if (_waveCounter || !sPoolMgr->IsSpawnedObject<Quest>(QUEST_DEPROGRAMMING))
-                    Summon(SummonEntries[addIndex], SummonPositions[addIndex * 3]);
-                else
-                    Summon(NPC_DARNAVAN, SummonPositions[addIndex * 3]);
-
+                Summon(SummonEntries[addIndex], SummonPositions[addIndex * 3]);
                 Summon(SummonEntries[addIndexOther], SummonPositions[addIndex * 3 + 1]);
                 Summon(SummonEntries[addIndex], SummonPositions[addIndex * 3 + 2]);
                 if (Is25ManRaid())
@@ -860,138 +779,6 @@ class npc_vengeful_shade : public CreatureScript
         }
 };
 
-class npc_darnavan : public CreatureScript
-{
-    public:
-        npc_darnavan() : CreatureScript("npc_darnavan") { }
-
-        struct npc_darnavanAI : public ScriptedAI
-        {
-            npc_darnavanAI(Creature* creature) : ScriptedAI(creature)
-            {
-                Initialize();
-            }
-
-            void Initialize()
-            {
-                _canCharge = true;
-                _canShatter = true;
-            }
-
-            void Reset() override
-            {
-                _events.Reset();
-                _events.ScheduleEvent(EVENT_DARNAVAN_BLADESTORM, Seconds(10));
-                _events.ScheduleEvent(EVENT_DARNAVAN_INTIMIDATING_SHOUT, Seconds(20), Seconds(25));
-                _events.ScheduleEvent(EVENT_DARNAVAN_MORTAL_STRIKE, Seconds(25), Seconds(30));
-                _events.ScheduleEvent(EVENT_DARNAVAN_SUNDER_ARMOR, Seconds(5), Seconds(8));
-                Initialize();
-            }
-
-            void JustDied(Unit* killer) override
-            {
-                _events.Reset();
-
-                if (!killer)
-                    return;
-
-                if (Player* owner = killer->GetCharmerOrOwnerPlayerOrPlayerItself())
-                {
-                    if (Group* group = owner->GetGroup())
-                    {
-                        for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
-                            if (Player* member = itr->GetSource())
-                                if (member->IsInMap(owner))
-                                    member->FailQuest(QUEST_DEPROGRAMMING);
-                    }
-                    else
-                        owner->FailQuest(QUEST_DEPROGRAMMING);
-                }
-            }
-
-            void MovementInform(uint32 type, uint32 id) override
-            {
-                if (type != POINT_MOTION_TYPE || id != POINT_DESPAWN)
-                    return;
-
-                me->DespawnOrUnsummon();
-            }
-
-            void JustEngagedWith(Unit* /*victim*/) override
-            {
-                Talk(SAY_DARNAVAN_AGGRO);
-            }
-
-            void UpdateAI(uint32 diff) override
-            {
-                if (!UpdateVictim())
-                    return;
-
-                _events.Update(diff);
-
-                if (me->HasUnitState(UNIT_STATE_CASTING))
-                    return;
-
-                if (_canShatter && me->GetVictim() && me->EnsureVictim()->IsImmunedToDamage(SPELL_SCHOOL_MASK_NORMAL))
-                {
-                    DoCastVictim(SPELL_SHATTERING_THROW);
-                    _canShatter = false;
-                    _events.ScheduleEvent(EVENT_DARNAVAN_SHATTERING_THROW, Seconds(30));
-                    return;
-                }
-
-                if (_canCharge && !me->IsWithinMeleeRange(me->GetVictim()))
-                {
-                    DoCastVictim(SPELL_CHARGE);
-                    _canCharge = false;
-                    _events.ScheduleEvent(EVENT_DARNAVAN_CHARGE, Seconds(20));
-                    return;
-                }
-
-                while (uint32 eventId = _events.ExecuteEvent())
-                {
-                    switch (eventId)
-                    {
-                        case EVENT_DARNAVAN_BLADESTORM:
-                            DoCast(SPELL_BLADESTORM);
-                            _events.ScheduleEvent(EVENT_DARNAVAN_BLADESTORM, Seconds(90), Seconds(100));
-                            break;
-                        case EVENT_DARNAVAN_CHARGE:
-                            _canCharge = true;
-                            break;
-                        case EVENT_DARNAVAN_INTIMIDATING_SHOUT:
-                            DoCast(SPELL_INTIMIDATING_SHOUT);
-                            _events.ScheduleEvent(EVENT_DARNAVAN_INTIMIDATING_SHOUT, Seconds(90), Minutes(2));
-                            break;
-                        case EVENT_DARNAVAN_MORTAL_STRIKE:
-                            DoCastVictim(SPELL_MORTAL_STRIKE);
-                            _events.ScheduleEvent(EVENT_DARNAVAN_MORTAL_STRIKE, Seconds(15), Seconds(30));
-                            break;
-                        case EVENT_DARNAVAN_SHATTERING_THROW:
-                            _canShatter = true;
-                            break;
-                        case EVENT_DARNAVAN_SUNDER_ARMOR:
-                            DoCastVictim(SPELL_SUNDER_ARMOR);
-                            _events.ScheduleEvent(EVENT_DARNAVAN_SUNDER_ARMOR, Seconds(3), Seconds(7));
-                            break;
-                    }
-                }
-
-                DoMeleeAttackIfReady();
-            }
-
-        private:
-            EventMap _events;
-            bool _canCharge;
-            bool _canShatter;
-        };
-
-        CreatureAI* GetAI(Creature* creature) const override
-        {
-            return GetIcecrownCitadelAI<npc_darnavanAI>(creature);
-        }
-};
-
 class spell_deathwhisper_mana_barrier : public SpellScriptLoader
 {
     public:
@@ -1109,7 +896,6 @@ void AddSC_boss_lady_deathwhisper()
     new npc_cult_fanatic();
     new npc_cult_adherent();
     new npc_vengeful_shade();
-    new npc_darnavan();
     new spell_deathwhisper_mana_barrier();
     new spell_deathwhisper_dominated_mind();
     new spell_deathwhisper_summon_spirits();

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_rotface.cpp
@@ -872,43 +872,6 @@ class spell_rotface_vile_gas_trigger : public SpellScriptLoader
         }
 };
 
-class spell_rotface_slime_spray : public SpellScriptLoader
-{
-    public:
-        spell_rotface_slime_spray() : SpellScriptLoader("spell_rotface_slime_spray") { }
-
-        class spell_rotface_slime_spray_SpellScript : public SpellScript
-        {
-            PrepareSpellScript(spell_rotface_slime_spray_SpellScript);
-
-            void HandleResidue()
-            {
-                Player* target = GetHitPlayer();
-                if (!target)
-                    return;
-
-                if (target->HasAura(SPELL_GREEN_BLIGHT_RESIDUE))
-                    return;
-
-                uint32 questId = target->GetMap()->Is25ManRaid() ? QUEST_RESIDUE_RENDEZVOUS_25 : QUEST_RESIDUE_RENDEZVOUS_10;
-                if (target->GetQuestStatus(questId) != QUEST_STATUS_INCOMPLETE)
-                    return;
-
-                target->CastSpell(target, SPELL_GREEN_BLIGHT_RESIDUE, TRIGGERED_FULL_MASK);
-            }
-
-            void Register() override
-            {
-                OnHit += SpellHitFn(spell_rotface_slime_spray_SpellScript::HandleResidue);
-            }
-        };
-
-        SpellScript* GetSpellScript() const override
-        {
-            return new spell_rotface_slime_spray_SpellScript();
-        }
-};
-
 void AddSC_boss_rotface()
 {
     new boss_rotface();
@@ -924,5 +887,4 @@ void AddSC_boss_rotface()
     new spell_rotface_unstable_ooze_explosion();
     new spell_rotface_unstable_ooze_explosion_suicide();
     new spell_rotface_vile_gas_trigger();
-    new spell_rotface_slime_spray();
 }

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -1638,9 +1638,6 @@ class at_sindragosa_lair : public AreaTriggerScript
 
                 if (!instance->GetData(DATA_SINDRAGOSA_FROSTWYRMS) && !instance->GetGuidData(DATA_SINDRAGOSA) && instance->GetBossState(DATA_SINDRAGOSA) != DONE)
                 {
-                    if (player->GetMap()->IsHeroic() && !instance->GetData(DATA_HEROIC_ATTEMPTS))
-                        return true;
-
                     player->GetMap()->LoadGrid(SindragosaSpawnPos.GetPositionX(), SindragosaSpawnPos.GetPositionY());
                     if (Creature* sindragosa = player->GetMap()->SummonCreature(NPC_SINDRAGOSA, SindragosaSpawnPos))
                         sindragosa->AI()->DoAction(ACTION_START_FROSTWYRM);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_valithria_dreamwalker.cpp
@@ -151,8 +151,6 @@ enum Misc
     DATA_SUPPRESSERS_COUNT = 4
 };
 
-Position const ValithriaSpawnPos = {4210.813f, 2484.443f, 364.9558f, 0.01745329f};
-
 class RisenArchmageCheck
 {
     public:

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.h
@@ -29,10 +29,7 @@ enum TriggerCastFlags : uint32;
 
 uint32 const EncounterCount = 13;
 uint32 const WeeklyNPCs = 9;
-uint32 const MaxHeroicAttempts = 50;
 
-// Defined in boss_valithria_dreamwalker.cpp
-extern Position const ValithriaSpawnPos;
 // Defined in boss_sindragosa.cpp
 extern Position const SindragosaSpawnPos;
 // Defined in boss_the_lich_king.cpp
@@ -106,8 +103,6 @@ enum ICDataTypes
     DATA_RIMEFANG                      = 25,
     DATA_COLDFLAME_JETS                = 26,
     DATA_TEAM_IN_INSTANCE              = 27,
-    DATA_BLOOD_QUICKENING_STATE        = 28,
-    DATA_HEROIC_ATTEMPTS               = 29,
     DATA_CROK_SCOURGEBANE              = 30,
     DATA_CAPTAIN_ARNATH                = 31,
     DATA_CAPTAIN_BRANDON               = 32,
@@ -152,19 +147,6 @@ enum ICCreaturesIds
     NPC_MURADIN_BRONZEBEARD_QUEST               = 38607,
     NPC_UTHER_THE_LIGHTBRINGER_QUEST            = 38608,
     NPC_LADY_SYLVANAS_WINDRUNNER_QUEST          = 38609,
-
-    // Weekly quests
-    NPC_INFILTRATOR_MINCHAR                     = 38471,
-    NPC_KOR_KRON_LIEUTENANT                     = 38491,
-    NPC_SKYBREAKER_LIEUTENANT                   = 38492,
-    NPC_ROTTING_FROST_GIANT_10                  = 38490,
-    NPC_ROTTING_FROST_GIANT_25                  = 38494,
-    NPC_ALCHEMIST_ADRIANNA                      = 38501,
-    NPC_ALRIN_THE_AGILE                         = 38551,
-    NPC_INFILTRATOR_MINCHAR_BQ                  = 38558,
-    NPC_INFILTRATOR_MINCHAR_BQ_25               = 39123,
-    NPC_MINCHAR_BEAM_STALKER                    = 38557,
-    NPC_VALITHRIA_DREAMWALKER_QUEST             = 38589,
 
     // Lord Marrowgar
     NPC_LORD_MARROWGAR                          = 36612,
@@ -487,9 +469,6 @@ enum ICSharedActions
     ACTION_ROTFACE_DEATH        = -366272,
     ACTION_CHANGE_PHASE         = -366780,
 
-    // Blood-Queen Lana'thel
-    ACTION_KILL_MINCHAR         = -379550,
-
     // Frostwing Halls gauntlet event
     ACTION_VRYKUL_DEATH         = 37129,
 
@@ -500,29 +479,6 @@ enum ICSharedActions
     // The Lich King
     ACTION_RESTORE_LIGHT        = -72262,
     ACTION_FROSTMOURNE_INTRO    = -36823
-};
-
-enum ICWeekliesICC
-{
-    QUEST_DEPROGRAMMING_10                  = 24869,
-    QUEST_DEPROGRAMMING_25                  = 24875,
-    QUEST_SECURING_THE_RAMPARTS_10          = 24870,
-    QUEST_SECURING_THE_RAMPARTS_25          = 24877,
-    QUEST_RESIDUE_RENDEZVOUS_10             = 24873,
-    QUEST_RESIDUE_RENDEZVOUS_25             = 24878,
-    QUEST_BLOOD_QUICKENING_10               = 24874,
-    QUEST_BLOOD_QUICKENING_25               = 24879,
-    QUEST_RESPITE_FOR_A_TORNMENTED_SOUL_10  = 24872,
-    QUEST_RESPITE_FOR_A_TORNMENTED_SOUL_25  = 24880
-};
-
-enum ICWorldStatesICC
-{
-    WORLDSTATE_SHOW_TIMER           = 4903,
-    WORLDSTATE_EXECUTION_TIME       = 4904,
-    WORLDSTATE_SHOW_ATTEMPTS        = 4940,
-    WORLDSTATE_ATTEMPTS_REMAINING   = 4941,
-    WORLDSTATE_ATTEMPTS_MAX         = 4942
 };
 
 enum ICAreaIds


### PR DESCRIPTION
…heroic retry counter since those got removed when Cataclysm launched.

This is *actually* preparation for anim tier cleanup.

Needed SQL:
```sql-- Cata removed ICC dailies
DELETE FROM spell_script_names WHERE ScriptName IN (
	"spell_rotface_slime_spray",
	"spell_frost_giant_death_plague",
	"spell_icc_harvest_blight_specimen"
);

UPDATE creature_template SET ScriptName = "" WHERE ScriptName IN (
	"npc_alchemist_adrianna",
	"npc_rotting_frost_giant",
	"npc_darnavan"
);

DELETE FROM areatrigger_scripts WHERE ScriptName IN (
	"at_icc_start_blood_quickening"
);

DELETE FROM creature WHERE id IN (
    38471, -- NPC_INFILTRATOR_MINCHAR
    38491, -- NPC_KOR_KRON_LIEUTENANT
    38492, -- NPC_SKYBREAKER_LIEUTENANT
    38490, -- NPC_ROTTING_FROST_GIANT_10
    38494, -- NPC_ROTTING_FROST_GIANT_25
    38501, -- NPC_ALCHEMIST_ADRIANNA
    38551, -- NPC_ALRIN_THE_AGILE
    38558, -- NPC_INFILTRATOR_MINCHAR_BQ
    39123, -- NPC_INFILTRATOR_MINCHAR_BQ_25
    38557, -- NPC_MINCHAR_BEAM_STALKER
    38589  -- NPC_VALITHRIA_DREAMWALKER_QUEST
);

```

Naturally, no test ingame.

Note: removed darnavan, I'm not sure he still spawns as of Cata+ (a quick search in sniff storage only shows him in WDC query responses, and only for Cata dumps at that)