### PR TITLE
Core/Spells: Implement SPELL_EFFECT_ACTIVATE_OBJECT.

### DIFF
--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -93,6 +93,9 @@ static FactionTeamMap sFactionTeamMap;
 DBCStorage <FactionEntry> sFactionStore(FactionEntryfmt);
 DBCStorage <FactionTemplateEntry> sFactionTemplateStore(FactionTemplateEntryfmt);
 
+// Used exclusively for data validation
+DBCStorage <GameObjectArtKitEntry> sGameObjectArtKitStore(GameObjectArtKitfmt);
+
 DBCStorage <GameObjectDisplayInfoEntry> sGameObjectDisplayInfoStore(GameObjectDisplayInfofmt);
 DBCStorage <GemPropertiesEntry> sGemPropertiesStore(GemPropertiesEntryfmt);
 DBCStorage <GlyphPropertiesEntry> sGlyphPropertiesStore(GlyphPropertiesfmt);
@@ -138,10 +141,10 @@ DBCStorage <ItemDamageEntry>              sItemDamageTwoHandCasterStore(ItemDama
 DBCStorage <ItemDamageEntry>              sItemDamageWandStore(ItemDamagefmt);
 DBCStorage <ItemDisenchantLootEntry>      sItemDisenchantLootStore(ItemDisenchantLootfmt);
 //DBCStorage <ItemDisplayInfoEntry> sItemDisplayInfoStore(ItemDisplayTemplateEntryfmt); -- not used currently
-DBCStorage <ItemLimitCategoryEntry> sItemLimitCategoryStore(ItemLimitCategoryEntryfmt);
-DBCStorage <ItemRandomPropertiesEntry> sItemRandomPropertiesStore(ItemRandomPropertiesfmt);
-DBCStorage <ItemRandomSuffixEntry> sItemRandomSuffixStore(ItemRandomSuffixfmt);
-DBCStorage <ItemSetEntry> sItemSetStore(ItemSetEntryfmt);
+DBCStorage <ItemLimitCategoryEntry>       sItemLimitCategoryStore(ItemLimitCategoryEntryfmt);
+DBCStorage <ItemRandomPropertiesEntry>    sItemRandomPropertiesStore(ItemRandomPropertiesfmt);
+DBCStorage <ItemRandomSuffixEntry>        sItemRandomSuffixStore(ItemRandomSuffixfmt);
+DBCStorage <ItemSetEntry>                 sItemSetStore(ItemSetEntryfmt);
 
 DBCStorage <LFGDungeonEntry> sLFGDungeonStore(LFGDungeonEntryfmt);
 DBCStorage <LFGDungeonsGroupingMapEntry> sLFGDungeonsGroupingMapStore(LFGDungeonsGroupingMapfmt);
@@ -374,6 +377,7 @@ void LoadDBCStores(const std::string& dataPath)
     LOAD_DBC(sEmotesTextStore,                    "EmotesText.dbc");//15595
     LOAD_DBC(sFactionStore,                       "Faction.dbc");//15595
     LOAD_DBC(sFactionTemplateStore,               "FactionTemplate.dbc");//15595
+    LOAD_DBC(sGameObjectArtKitStore,              "GameObjectArtKit.dbc");//15595
     LOAD_DBC(sGameObjectDisplayInfoStore,         "GameObjectDisplayInfo.dbc");//15595
     LOAD_DBC(sGemPropertiesStore,                 "GemProperties.dbc");//15595
     LOAD_DBC(sGlyphPropertiesStore,               "GlyphProperties.dbc");//15595

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -129,6 +129,7 @@ TC_GAME_API extern DBCStorage <EmotesTextEntry>              sEmotesTextStore;
 TC_GAME_API extern DBCStorage <EmotesTextSoundEntry>         sEmotesTextSoundStore;
 TC_GAME_API extern DBCStorage <FactionEntry>                 sFactionStore;
 TC_GAME_API extern DBCStorage <FactionTemplateEntry>         sFactionTemplateStore;
+TC_GAME_API extern DBCStorage <GameObjectArtKitEntry>        sGameObjectArtKitStore;
 TC_GAME_API extern DBCStorage <GameObjectDisplayInfoEntry>   sGameObjectDisplayInfoStore;
 TC_GAME_API extern DBCStorage <GemPropertiesEntry>           sGemPropertiesStore;
 TC_GAME_API extern DBCStorage <GlyphPropertiesEntry>         sGlyphPropertiesStore;

--- a/src/server/game/DataStores/DBCStructure.h
+++ b/src/server/game/DataStores/DBCStructure.h
@@ -1198,8 +1198,8 @@ struct FactionTemplateEntry
 struct GameObjectArtKitEntry
 {
     uint32 ID;                                              // 0
-                                                            // 1-3 m_textureVariations[3]
-                                                            // 4-8 m_attachModels[4]
+    //char* TextureVariation[3]                             // 1-3 m_textureVariations[3]
+    //char* AttachModel[4]                                  // 4-8 m_attachModels[4]
 };
 
 struct GameObjectDisplayInfoEntry

--- a/src/server/game/DataStores/DBCStructure.h
+++ b/src/server/game/DataStores/DBCStructure.h
@@ -1195,6 +1195,13 @@ struct FactionTemplateEntry
     bool IsContestedGuardFaction() const { return (factionFlags & FACTION_TEMPLATE_FLAG_CONTESTED_GUARD) != 0; }
 };
 
+struct GameObjectArtKitEntry
+{
+    uint32 ID;                                              // 0
+                                                            // 1-3 m_textureVariations[3]
+                                                            // 4-8 m_attachModels[4]
+};
+
 struct GameObjectDisplayInfoEntry
 {
     uint32      Displayid;                                  // 0        m_ID

--- a/src/server/game/DataStores/DBCfmt.h
+++ b/src/server/game/DataStores/DBCfmt.h
@@ -62,6 +62,7 @@ char const EmotesTextEntryfmt[] = "nxixxxxxxxxxxxxxxxx";
 char const EmotesTextSoundEntryfmt[] = "niiii";
 char const FactionEntryfmt[] = "niiiiiiiiiiiiiiiiiiffixsxi";
 char const FactionTemplateEntryfmt[] = "niiiiiiiiiiiii";
+char const GameObjectArtKitfmt[] = "nxxxxxxx";
 char const GameObjectDisplayInfofmt[] = "nsxxxxxxxxxxffffffxxx";
 char const GemPropertiesEntryfmt[] = "nixxii";
 char const GlyphPropertiesfmt[] = "niii";

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -1277,6 +1277,32 @@ void GameObject::UseDoorOrButton(uint32 time_to_restore, bool alternative /* = f
     m_cooldownTime = time_to_restore ? (GameTime::GetGameTimeMS() + time_to_restore) : 0;
 }
 
+void GameObject::PlayAnimKit(int32 animKit)
+{
+    WorldPacket data(SMSG_GAME_OBJECT_ACTIVATE_ANIM_KIT, 4 + 2);
+
+    ObjectGuid guid = GetGUID();
+    data.WriteBit(guid[5]);
+    data.WriteBit(guid[1]);
+    data.WriteBit(guid[0]);
+    data.WriteBit(guid[4]);
+    data.WriteBit(guid[7]);
+    data.WriteBit(guid[2]);
+    data.WriteBit(guid[3]);
+    data.WriteBit(guid[6]);
+    data.WriteByteSeq(guid[5]);
+    data.WriteByteSeq(guid[1]);
+    data.WriteByteSeq(guid[0]);
+    data.WriteByteSeq(guid[3]);
+    data.WriteByteSeq(guid[4]);
+    data.WriteByteSeq(guid[6]);
+    data.WriteByteSeq(guid[2]);
+    data.WriteByteSeq(guid[7]);
+    data << int32(animKit);
+
+    SendMessageToSet(&data, nullptr);
+}
+
 void GameObject::SetGoArtKit(uint8 kit)
 {
     SetByteValue(GAMEOBJECT_BYTES_1, 2, kit);

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -169,6 +169,8 @@ class TC_GAME_API GameObject : public WorldObject, public GridObject<GameObject>
         void SetGoAnimProgress(uint8 animprogress) { SetByteValue(GAMEOBJECT_BYTES_1, 3, animprogress); }
         static void SetGoArtKit(uint8 artkit, GameObject* go, ObjectGuid::LowType lowguid = 0);
 
+        void PlayAnimKit(int32 animKit);
+
         void EnableCollision(bool enable);
 
         void Use(Unit* user);

--- a/src/server/game/Entities/GameObject/GameObjectData.h
+++ b/src/server/game/Entities/GameObject/GameObjectData.h
@@ -22,9 +22,10 @@
 #include "SharedDefines.h"
 #include "SpawnData.h"
 #include "WorldPacket.h"
+
+#include <array>
 #include <string>
 #include <vector>
-
 
 #define MAX_GAMEOBJECT_QUEST_ITEMS 6
 
@@ -597,6 +598,7 @@ struct GameObjectTemplateAddon
     uint32  flags;
     uint32  mingold;
     uint32  maxgold;
+    std::array<uint32, 5> artKits;
 };
 
 struct GameObjectLocale
@@ -632,6 +634,49 @@ struct GameObjectData : public SpawnData
     uint32 animprogress = 0;
     GOState goState = GO_STATE_ACTIVE;
     uint8 artKit = 0;
+};
+
+enum class GameObjectActions : uint32
+{
+    // Name from client executable      // Comments
+    None,                           // -NONE-
+    AnimateCustom0,                 // Animate Custom0
+    AnimateCustom1,                 // Animate Custom1
+    AnimateCustom2,                 // Animate Custom2
+    AnimateCustom3,                 // Animate Custom3
+    Disturb,                        // Disturb                          // Triggers trap
+    Unlock,                         // Unlock                           // Resets GO_FLAG_LOCKED
+    Lock,                           // Lock                             // Sets GO_FLAG_LOCKED
+    Open,                           // Open                             // Sets GO_STATE_ACTIVE
+    OpenAndUnlock,                  // Open + Unlock                    // Sets GO_STATE_ACTIVE and resets GO_FLAG_LOCKED
+    Close,                          // Close                            // Sets GO_STATE_READY
+    ToggleOpen,                     // Toggle Open
+    Destroy,                        // Destroy                          // Sets GO_STATE_DESTROYED
+    Rebuild,                        // Rebuild                          // Resets from GO_STATE_DESTROYED
+    Creation,                       // Creation
+    Despawn,                        // Despawn
+    MakeInert,                      // Make Inert                       // Disables interactions
+    MakeActive,                     // Make Active                      // Enables interactions
+    CloseAndLock,                   // Close + Lock                     // Sets GO_STATE_READY and sets GO_FLAG_LOCKED
+    UseArtKit0,                     // Use ArtKit0                      // 46904: 121
+    UseArtKit1,                     // Use ArtKit1                      // 36639: 81, 46903: 122
+    UseArtKit2,                     // Use ArtKit2
+    UseArtKit3,                     // Use ArtKit3
+    SetTapList,                     // Set Tap List
+    GoTo1stFloor,                   // Go to 1st floor
+    GoTo2ndFloor,                   // Go to 2nd floor
+    GoTo3rdFloor,                   // Go to 3rd floor
+    GoTo4thFloor,                   // Go to 4th floor
+    GoTo5thFloor,                   // Go to 5th floor
+    GoTo6thFloor,                   // Go to 6th floor
+    GoTo7thFloor,                   // Go to 7th floor
+    GoTo8thFloor,                   // Go to 8th floor
+    GoTo9thFloor,                   // Go to 9th floor
+    GoTo10thFloor,                  // Go to 10th floor
+    UseArtKit4,                     // Use ArtKit4
+    PlayAnimKit,                    // Play Anim Kit "%s"               // MiscValueB -> Anim Kit ID
+    OpenAndPlayAnimKit,             // Open + Play Anim Kit "%s"        // MiscValueB -> Anim Kit ID
+    CloseAndPlayAnimKit,            // Close + Play Anim Kit "%s"       // MiscValueB -> Anim Kit ID
 };
 
 #endif // GameObjectData_h__

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -7488,8 +7488,8 @@ void ObjectMgr::LoadGameObjectTemplateAddons()
 {
     uint32 oldMSTime = getMSTime();
 
-    //                                                0       1       2      3        4
-    QueryResult result = WorldDatabase.Query("SELECT entry, faction, flags, mingold, maxgold FROM gameobject_template_addon");
+    //                                                0       1       2      3        4       5        6        7        8        9
+    QueryResult result = WorldDatabase.Query("SELECT entry, faction, flags, mingold, maxgold, artkit0, artkit1, artkit2, artkit3, artkit4 FROM gameobject_template_addon");
 
     if (!result)
     {
@@ -7517,6 +7517,9 @@ void ObjectMgr::LoadGameObjectTemplateAddons()
         gameObjectAddon.mingold = fields[3].GetUInt32();
         gameObjectAddon.maxgold = fields[4].GetUInt32();
 
+        for (uint32 i = 0; i < gameObjectAddon.artKits.size(); ++i)
+            gameObjectAddon.artKits[i] = fields[5 + i].GetUInt32();
+
         // checks
         if (gameObjectAddon.faction && !sFactionTemplateStore.LookupEntry(gameObjectAddon.faction))
             TC_LOG_ERROR("sql.sql", "GameObject (Entry: %u) has invalid faction (%u) defined in `gameobject_template_addon`.", entry, gameObjectAddon.faction);
@@ -7531,6 +7534,21 @@ void ObjectMgr::LoadGameObjectTemplateAddons()
                 default:
                     TC_LOG_ERROR("sql.sql", "GameObject (Entry %u GoType: %u) cannot be looted but has maxgold set in `gameobject_template_addon`.", entry, got->type);
                     break;
+            }
+        }
+
+        uint32 artKitIndex = 0;
+        for (uint32& artKitID : gameObjectAddon.artKits)
+        {
+            ++artKitIndex;
+            if (artKitID == 0)
+                continue;
+
+            if (sGameObjectArtKitStore.LookupEntry(artKitID) == nullptr)
+            {
+                TC_LOG_ERROR("sql.sql", "GameObject (Entry: %u) has invalid `artkit%d` (%d) defined, set to zero instead.", entry, artKitIndex - 1, artKitID);
+
+                artKitID = 0;
             }
         }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -7541,13 +7541,12 @@ void ObjectMgr::LoadGameObjectTemplateAddons()
         for (uint32& artKitID : gameObjectAddon.artKits)
         {
             ++artKitIndex;
-            if (artKitID == 0)
+            if (!artKitID)
                 continue;
 
-            if (sGameObjectArtKitStore.LookupEntry(artKitID) == nullptr)
+            if (!sGameObjectArtKitStore.LookupEntry(artKitID))
             {
                 TC_LOG_ERROR("sql.sql", "GameObject (Entry: %u) has invalid `artkit%d` (%d) defined, set to zero instead.", entry, artKitIndex - 1, artKitID);
-
                 artKitID = 0;
             }
         }

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
@@ -469,26 +469,8 @@ private:
     bool _firstGuardian;
 };
 
-// 45226 - Banging the Gong
-class spell_banging_the_gong : public SpellScript
-{
-    PrepareSpellScript(spell_banging_the_gong);
-
-    void Activate(SpellEffIndex effIndex)
-    {
-        PreventHitDefaultEffect(effIndex);
-        GetHitGObj()->SendCustomAnim(0);
-    }
-
-    void Register() override
-    {
-        OnEffectHitTarget += SpellEffectFn(spell_banging_the_gong::Activate, EFFECT_1, SPELL_EFFECT_ACTIVATE_OBJECT);
-    }
-};
-
 void AddSC_zulaman()
 {
     RegisterZulAamanCreatureAI(npc_zulaman_voljin);
     RegisterZulAamanCreatureAI(npc_zulaman_amanishi_guardian);
-    RegisterSpellScript(spell_banging_the_gong);
 }

--- a/src/server/scripts/Kalimdor/HallsOfOrigination/boss_temple_guardian_anhuur.cpp
+++ b/src/server/scripts/Kalimdor/HallsOfOrigination/boss_temple_guardian_anhuur.cpp
@@ -422,33 +422,6 @@ class spell_anhuur_disable_beacon_beams : public SpellScript
     }
 };
 
-// 76599 - Activate Beacons
-// 76600 - Deactivate Beacons
-class spell_anhuur_handle_beacons : public SpellScript
-{
-    PrepareSpellScript(spell_anhuur_handle_beacons);
-
-    void HandleEffect(SpellEffIndex effIndex)
-    {
-        PreventHitDefaultEffect(effIndex);
-        int32 script = GetSpellInfo()->Effects[effIndex].MiscValue;
-
-        GameObject* beacon = GetHitGObj();
-        if (!beacon)
-            return;
-
-        if (script == 16) // 16 => Disable
-            beacon->SetFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
-        else if (script == 17) // 17 => Activate
-            beacon->RemoveFlag(GAMEOBJECT_FLAGS, GO_FLAG_IN_USE);
-    }
-
-    void Register() override
-    {
-        OnEffectHitTarget += SpellEffectFn(spell_anhuur_handle_beacons::HandleEffect, EFFECT_0, SPELL_EFFECT_ACTIVATE_OBJECT);
-    }
-};
-
 class spell_anhuur_burning_light_forcecast : public SpellScript
 {
     PrepareSpellScript(spell_anhuur_burning_light_forcecast);
@@ -493,7 +466,6 @@ void AddSC_boss_temple_guardian_anhuur()
     RegisterSpellScript(spell_anhuur_shield_of_light),
     RegisterAuraScript(spell_anhuur_reverberating_hymn);
     RegisterSpellScript(spell_anhuur_disable_beacon_beams);
-    RegisterSpellScript(spell_anhuur_handle_beacons);
     RegisterSpellScript(spell_anhuur_burning_light_forcecast);
     new achievement_i_hate_that_song();
 }


### PR DESCRIPTION
Needed SQL:

```sql
ALTER TABLE `gameobject_template_addon`
	ADD COLUMN `artkit0` INT NOT NULL DEFAULT 0 AFTER `maxgold`,
	ADD COLUMN `artkit1` INT NOT NULL DEFAULT 0 AFTER `artkit0`,
	ADD COLUMN `artkit2` INT NOT NULL DEFAULT 0 AFTER `artkit1`,
	ADD COLUMN `artkit3` INT NOT NULL DEFAULT 0 AFTER `artkit2`,
	ADD COLUMN `artkit4` INT NOT NULL DEFAULT 0 AFTER `artkit3`;
```

```sql
-- Note: All of these should be targettable by spells 46904 and 46903, but conditions are only set for Stormwind (damn Horde fanatics)
UPDATE gameobject_template SET artkit0 = 121, arkit1 = 122 WHERE entry IN (
	188352, -- Flame of Shattrath
	188129, -- Flame of Silvermoon
	188128, -- Flame of the Exodar
	181567, -- Flame of the Wetlands
	181566, -- Flame of Hillsbrad
	181565, -- Flame of Westfall
	181564, -- Flame of Silverpine
	181563, -- Flame of Darkshore
	181562, -- Flame of Stonetalon
	181561, -- Flame of Ashenvale
	181560, -- Flame of the Barrens
	181349, -- Flame of the Scholomance
	181348, -- Flame of Stratholme
	181347, -- Flame of Blackrock Spire
	181346, -- Flame of Dire Maul
	181345, -- Flame of the Hinterlands
	181344, -- Flame of the Blasted Lands
	181343, -- Flame of Un'Goro
	181342, -- Flame of Azshara
	181341, -- Flame of Searing Gorge
	181340, -- Flame of Winterspring
	181339, -- Flame of Silithus
	181338, -- Flame of the Plaguelands
	181337, -- Flame of Thunder Bluff
	181336, -- Flame of Orgrimmar
	181335, -- Flame of the Undercity
	181334, -- Flame of Darnassus
	181333, -- Flame of Ironforge
	181332  -- Flame of Stormwind
);

DELETE FROM `spell_script_names` WHERE `ScriptName`= "spell_banging_the_gong";
DELETE FROM `spell_script_names` WHERE `ScriptName`= "spell_anhuur_handle_beacons";
```

Did not bother checking for values implemented post-Cata.

**Tests performed:**
- Banging the gong in ZA

**Remarks:**
- `SetTapList` is not implemented. It's probably used to bind gameobject loot to a boss - hello, Ultraxion; hello, Deathbringer Saurfang. But we have other ways to do that.

**FYI:**
![](https://i.imgur.com/OlUeUEg.png)
Curiously enough, Release Assertions builds around the Cata era do not have that enum. But 15595 itself does. /shrug