### PR TITLE
Core/Movement: Fixed Animation Tier handling.

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -1787,6 +1787,7 @@ void Creature::setDeathState(DeathState s)
         uint32 respawnDelay = m_respawnDelay;
         if (uint32 scalingMode = sWorld->getIntConfig(CONFIG_RESPAWN_DYNAMICMODE))
             GetMap()->ApplyDynamicModeRespawnScaling(this, m_spawnId, respawnDelay, scalingMode);
+
         // @todo remove the boss respawn time hack in a dynspawn follow-up once we have creature groups in instances
         if (m_respawnCompatibilityMode)
         {
@@ -1822,7 +1823,8 @@ void Creature::setDeathState(DeathState s)
             m_formation->FormationReset(true);
 
         bool needsFalling = (IsFlying() || IsHovering()) && !IsUnderWater();
-        SetHover(false);
+        SetHover(false, false);
+        SetDisableGravity(false, false);
 
         if (needsFalling)
             GetMotionMaster()->MoveFall();
@@ -2410,7 +2412,8 @@ bool Creature::LoadCreaturesAddon()
         //SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_PET_TALENTS, uint8((cainfo->bytes1 >> 8) & 0xFF));
         SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_PET_TALENTS, 0);
         SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_VIS_FLAG, uint8((cainfo->bytes1 >> 16) & 0xFF));
-        SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, uint8((cainfo->bytes1 >> 24) & 0xFF));
+
+        SetAnimationTier(static_cast<AnimationTier>((cainfo->bytes1 >> 24) & 0xFF));
 
         //! Suspected correlation between UNIT_FIELD_BYTES_1, offset 3, value 0x2:
         //! If no inhabittype_fly (if no MovementFlag_DisableGravity or MovementFlag_CanFly flag found in sniffs)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -4246,7 +4246,7 @@ void Player::BuildPlayerRepop()
     StopMirrorTimers();                                     //disable timers(bars)
 
     // set and clear other
-    SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND);
+    SetAnimationTier(AnimationTier::Ground, false);
 
     // OnPlayerRepop hook
     sScriptMgr->OnPlayerRepop(this);
@@ -4264,7 +4264,7 @@ void Player::ResurrectPlayer(float restore_percent, bool applySickness)
     // speed change, land walk
 
     // remove death flag + set aura
-    SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, 0);
+    SetAnimationTier(AnimationTier::Ground);
     RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_IS_OUT_OF_BOUNDS);
 
     // This must be called always even on Players with race != RACE_NIGHTELF in case of faction change

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -262,7 +262,6 @@ namespace Movement
 {
     class ExtraMovementStatusElement;
     class MoveSpline;
-    enum AnimType : uint8;
 }
 
 typedef std::list<Unit*> UnitList;
@@ -1164,6 +1163,9 @@ class TC_GAME_API Unit : public WorldObject
         bool IsStandState() const;
         void SetStandState(uint8 state);
 
+        void SetAnimationTier(AnimationTier tier, bool immediate = true);
+        AnimationTier GetAnimationTier() const { return static_cast<AnimationTier>(GetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER)); }
+
         void  SetStandFlags(uint8 flags) { SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_VIS_FLAG, flags); }
         void  RemoveStandFlags(uint8 flags) { RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_VIS_FLAG, flags); }
 
@@ -1342,19 +1344,19 @@ class TC_GAME_API Unit : public WorldObject
         void MonsterMoveWithSpeed(float x, float y, float z, float speed, bool generatePath = false, bool forceDestination = false);
 
         void SendSetPlayHoverAnim(bool enable);
-        void SendMovementSetSplineAnim(Movement::AnimType anim);
+        void SendMovementSetSplineAnim(AnimationTier anim);
 
         bool IsGravityDisabled() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY); }
         bool IsWalking() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_WALKING); }
         bool IsHovering() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_HOVER); }
         bool SetWalk(bool enable);
-        bool SetDisableGravity(bool disable, bool packetOnly = false);
+        bool SetDisableGravity(bool disable, bool packetOnly = false, bool updateAnimationTier = true);
         bool SetFall(bool enable);
         bool SetSwim(bool enable);
         bool SetCanFly(bool enable, bool packetOnly = false);
         bool SetWaterWalking(bool enable, bool packetOnly = false);
         bool SetFeatherFall(bool enable, bool packetOnly = false);
-        bool SetHover(bool enable, bool packetOnly = false);
+        bool SetHover(bool enable, bool packetOnly = false, bool updateAnimationTier = true);
 
         void SetInFront(WorldObject const* target);
         void SetFacingTo(float const ori, bool force = true);

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -77,13 +77,14 @@ enum UnitBytes2Offsets : uint8
     UNIT_BYTES_2_OFFSET_SHAPESHIFT_FORM = 3,
 };
 
-// byte flags value (UNIT_FIELD_BYTES_1, 3)
-enum UnitBytes1_Flags : uint8
+// UNIT_FIELD_BYTES_1 (UNIT_BYTES_1_OFFSET_ANIM_TIER)
+enum class AnimationTier : uint8
 {
-    UNIT_BYTE1_FLAG_ALWAYS_STAND    = 0x01,
-    UNIT_BYTE1_FLAG_HOVER           = 0x02,
-    UNIT_BYTE1_FLAG_UNK_3           = 0x04,
-    UNIT_BYTE1_FLAG_ALL             = 0xFF
+    Ground = 0,
+    Swim = 1,
+    Hover = 2,
+    Fly = 3,
+    Submerged = 4,
 };
 
 // low byte (0 from 0..3) of UNIT_FIELD_BYTES_2

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -346,7 +346,7 @@ void MotionMaster::MoveLand(uint32 id, Position const& pos, Optional<float> velo
     init.MoveTo(PositionToVector3(pos), false);
     init.SetSmooth();
     init.SetFly();
-    init.SetAnimation(Movement::ToGround);
+    init.SetAnimation(AnimationTier::Ground);
     if (velocity)
         init.SetVelocity(velocity.get());
     Mutate(new GenericMovementGenerator(std::move(init), EFFECT_MOTION_TYPE, id), MOTION_SLOT_ACTIVE);
@@ -360,7 +360,7 @@ void MotionMaster::MoveTakeoff(uint32 id, Position const& pos)
     init.MoveTo(PositionToVector3(pos), false);
     init.SetSmooth();
     init.SetFly();
-    init.SetAnimation(Movement::ToFly);
+    init.SetAnimation(AnimationTier::Hover);
     Mutate(new GenericMovementGenerator(std::move(init), EFFECT_MOTION_TYPE, id), MOTION_SLOT_ACTIVE);
 }
 
@@ -482,7 +482,7 @@ void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool 
     {
         init.SetFly();
         init.SetCyclic();
-        init.SetAnimation(Movement::ToFly);
+        init.SetAnimation(AnimationTier::Hover);
         init.SetUncompressed();
     }
     else

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -196,10 +196,10 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature* creature, bool rel
     switch (waypoint.moveType)
     {
         case WAYPOINT_MOVE_TYPE_LAND:
-            init.SetAnimation(Movement::ToGround);
+            init.SetAnimation(AnimationTier::Ground);
             break;
         case WAYPOINT_MOVE_TYPE_TAKEOFF:
-            init.SetAnimation(Movement::ToFly);
+            init.SetAnimation(AnimationTier::Hover);
             break;
         case WAYPOINT_MOVE_TYPE_RUN:
             init.SetWalk(false);

--- a/src/server/game/Movement/Spline/MoveSpline.h
+++ b/src/server/game/Movement/Spline/MoveSpline.h
@@ -22,6 +22,8 @@
 #include "MoveSplineInitArgs.h"
 #include <G3D/Vector3.h>
 
+enum class AnimationTier : uint8;
+
 namespace Movement
 {
     struct Location : public Vector3
@@ -124,6 +126,9 @@ namespace Movement
         Vector3 CurrentDestination() const { return Initialized() ? spline.getPoint(point_Idx + 1) : Vector3(); }
         int32 currentPathIdx() const;
         bool HasStarted() const { return time_passed > 0; }
+
+        bool HasAnimation() const { return splineflags.animation; }
+        AnimationTier GetAnimation() const { return static_cast<AnimationTier>(splineflags.animId); }
 
         bool onTransport;
         std::string ToString() const;

--- a/src/server/game/Movement/Spline/MoveSplineFlag.h
+++ b/src/server/game/Movement/Spline/MoveSplineFlag.h
@@ -63,7 +63,7 @@ namespace Movement
 
             // Masks
             Mask_Final_Facing   = Final_Point | Final_Target | Final_Angle,
-            // animation ids stored here, see AnimType enum, used with Animation flag
+            // animation ids stored here, see AimationTier enum, used with Animation flag
             Mask_Animations     = 0x7,
             // flags that shouldn't be appended into SMSG_MONSTER_MOVE\SMSG_MONSTER_MOVE_TRANSPORT packet, should be more probably
             Mask_No_Monster_Move = Mask_Final_Facing | Mask_Animations | Done,

--- a/src/server/game/Movement/Spline/MoveSplineInit.h
+++ b/src/server/game/Movement/Spline/MoveSplineInit.h
@@ -22,16 +22,10 @@
 
 class Unit;
 
+enum class AnimationTier : uint8;
+
 namespace Movement
 {
-    enum AnimType : uint8
-    {
-        ToGround    = 0, // 460 = ToGround, index of AnimationData.dbc
-        FlyToFly    = 1, // 461 = FlyToFly?
-        ToFly       = 2, // 458 = ToFly
-        FlyToGround = 3  // 463 = FlyToGround
-    };
-
     // Transforms coordinates from global to transport offsets
     class TC_GAME_API TransportPathTransform
     {
@@ -75,7 +69,7 @@ namespace Movement
         /* Plays animation after movement done
          * can't be combined with parabolic movement
          */
-        void SetAnimation(AnimType anim);
+        void SetAnimation(AnimationTier anim);
 
         /* Adds final facing animation
          * sets unit's facing to specified point/angle after all path done
@@ -178,7 +172,7 @@ namespace Movement
         args.flags.EnableParabolic();
     }
 
-    inline void MoveSplineInit::SetAnimation(AnimType anim)
+    inline void MoveSplineInit::SetAnimation(AnimationTier anim)
     {
         args.time_perc = 0.f;
         args.flags.EnableAnimation((uint8)anim);

--- a/src/server/scripts/EasternKingdoms/BastionOfTwilight/boss_theralion_and_valiona.cpp
+++ b/src/server/scripts/EasternKingdoms/BastionOfTwilight/boss_theralion_and_valiona.cpp
@@ -286,7 +286,7 @@ class boss_theralion : public CreatureScript
                 instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
                 me->SendSetPlayHoverAnim(false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+
                 summons.DespawnAll();
                 _DespawnAtEvade();
             }
@@ -323,7 +323,6 @@ class boss_theralion : public CreatureScript
                         me->PlayOneShotAnimKitId(ANIM_KIT_LIFTOFF);
                         me->SetDisableGravity(true);
                         me->SendSetPlayHoverAnim(true);
-                        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         _dazzlingDestructionCount = 0;
                         events.SetPhase(PHASE_AIR);
                         events.CancelEvent(EVENT_FABULOUS_FLAMES);
@@ -368,7 +367,6 @@ class boss_theralion : public CreatureScript
                     case POINT_LAND:
                         me->SetDisableGravity(false);
                         me->SendSetPlayHoverAnim(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         events.ScheduleEvent(EVENT_ATTACK_PLAYERS, Seconds(2));
                         break;
                     default:
@@ -551,7 +549,6 @@ class boss_valiona : public CreatureScript
                 instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
                 me->SendSetPlayHoverAnim(false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 summons.DespawnAll();
                 _DespawnAtEvade();
             }
@@ -591,7 +588,6 @@ class boss_valiona : public CreatureScript
                         me->PlayOneShotAnimKitId(ANIM_KIT_LIFTOFF);
                         me->SetDisableGravity(true);
                         me->SendSetPlayHoverAnim(true);
-                        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         _deepBreathCount = 0;
                         events.ScheduleEvent(EVENT_FLY_TO_DESTINATION, Seconds(1));
                         events.ScheduleEvent(EVENT_DEEP_BREATH, Minutes(1) + Seconds(25) + Milliseconds(100));
@@ -648,7 +644,6 @@ class boss_valiona : public CreatureScript
                     case POINT_LAND:
                         me->SetDisableGravity(false);
                         me->SendSetPlayHoverAnim(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         events.ScheduleEvent(EVENT_ATTACK_PLAYERS, Seconds(2));
                         events.ScheduleEvent(EVENT_BLACKOUT, Seconds(10) + Milliseconds(500));
                         events.ScheduleEvent(EVENT_DEVOURING_FLAMES, Seconds(25));

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingDescent/boss_atramedes.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingDescent/boss_atramedes.cpp
@@ -362,12 +362,10 @@ struct boss_atramedes : public BossAI
             case POINT_LAND_INTRO:
                 me->SetDisableGravity(false);
                 me->SendSetPlayHoverAnim(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
                 me->HandleEmoteCommand(EMOTE_ONESHOT_ROAR);
                 me->SetReactState(REACT_AGGRESSIVE);
                 break;
             case POINT_LIFTOFF:
-                me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
                 me->SetDisableGravity(true);
                 Talk(SAY_FLIGHT_PHASE);
                 DoCastSelf(SPELL_SONAR_PULSE_TRIGGER);
@@ -375,7 +373,6 @@ struct boss_atramedes : public BossAI
                 events.ScheduleEvent(EVENT_LAND, 31s, 0, PHASE_AIR);
                 break;
             case POINT_LAND:
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
                 me->SetDisableGravity(false);
                 me->SendSetPlayHoverAnim(false);
                 events.SetPhase(PHASE_GROUND);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingDescent/boss_nefarians_end.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingDescent/boss_nefarians_end.cpp
@@ -407,7 +407,7 @@ struct boss_nefarians_end : public BossAI
         else
         {
             me->AddUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+            me->SetAnimationTier(AnimationTier::Fly);
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_SELECTABLE);
             me->GetMotionMaster()->MoveCyclicPath(NefarianCyclicRespawnPath, CyclicRespawnPathPoints, false, true, 14.0f);
             DoCastSelf(SPELL_INTRO_5A_START_FIGHT_PROC);
@@ -634,10 +634,8 @@ struct boss_nefarians_end : public BossAI
                 case EVENT_REMOVE_TRANSFORM_AURA:
                     me->RemoveAurasDueToSpell(SPELL_INTRO_2_STALKER_TRANSFORM);
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
-                    me->SendMovementSetSplineAnim(Movement::AnimType::FlyToGround);
-                    me->SetUnitMovementFlags(MOVEMENTFLAG_DISABLE_GRAVITY);
+                    me->SetDisableGravity(true);
                     me->SendSetPlayHoverAnim(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     events.ScheduleEvent(EVENT_LIFT_OFF, 2s, 0, PHASE_ONE);
                     break;
                 case EVENT_LIFT_OFF:
@@ -664,8 +662,6 @@ struct boss_nefarians_end : public BossAI
                 case EVENT_LANDED:
                     me->SetDisableGravity(false);
                     me->SendSetPlayHoverAnim(false);
-                    me->SendMovementSetSplineAnim(Movement::AnimType::ToGround);
-                    me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
 
                     if (events.IsInPhase(PHASE_ONE))
                     {
@@ -735,9 +731,7 @@ struct boss_nefarians_end : public BossAI
                     DoCastSelf(SPELL_NEFARIAN_PHASE_2_HEALTH_AURA);
                     me->SetDisableGravity(true);
                     me->SendSetPlayHoverAnim(true);
-                    me->SendMovementSetSplineAnim(Movement::AnimType::FlyToGround);
                     me->GetMotionMaster()->MovePoint(POINT_NONE, NefarianElevatorLiftOffPosition);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     events.ScheduleEvent(EVENT_SUMMON_CHROMATIC_PROTOTYPES, 400ms, 0, PHASE_TWO);
                     events.ScheduleEvent(EVENT_LOWER_ELEVATOR, 800ms, 0, PHASE_TWO);
                     events.ScheduleEvent(EVENT_SAY_PHASE_TWO, 4s + 800ms, 0, PHASE_TWO);

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingDescent/instance_blackwing_descent.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingDescent/instance_blackwing_descent.cpp
@@ -319,7 +319,6 @@ class instance_blackwing_descent : public InstanceMapScript
                             atramedes->SetDisableGravity(true);
                             atramedes->SetReactState(REACT_PASSIVE);
                             atramedes->SendSetPlayHoverAnim(true);
-                            atramedes->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
                             atramedes->AI()->DoAction(ACTION_START_ATRAMEDES_INTRO);
                         }
 

--- a/src/server/scripts/EasternKingdoms/Gilneas/gilneas_chapter_1.cpp
+++ b/src/server/scripts/EasternKingdoms/Gilneas/gilneas_chapter_1.cpp
@@ -732,8 +732,8 @@ struct npc_gilnean_crow : public PassiveAI
             switch (eventId)
             {
                 case EVENT_APPLY_HOVER_BYTES:
-                    me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_STAND_STATE, UNIT_BYTE1_FLAG_ALWAYS_STAND);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_UNK_3);
+                    me->SetStandState(UNIT_STAND_STATE_SIT);
+                    me->SetAnimationTier(AnimationTier::Submerged);
                     _events.ScheduleEvent(EVENT_FLY_AWAY_1, 1s);
                     break;
                 case EVENT_FLY_AWAY_1:

--- a/src/server/scripts/EasternKingdoms/GrimBatol/boss_drahga_shadowburner.cpp
+++ b/src/server/scripts/EasternKingdoms/GrimBatol/boss_drahga_shadowburner.cpp
@@ -290,7 +290,8 @@ class npc_drahga_valiona : public CreatureScript
             {
                 me->SetDisableGravity(true);
                 me->SetHover(true);
-                me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                // TODO: See the Pull Request.
+
                 me->SetSpeed(MOVE_FLIGHT, 4.5f);
                 me->SetReactState(REACT_PASSIVE);
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
@@ -319,11 +320,8 @@ class npc_drahga_valiona : public CreatureScript
                         me->GetMotionMaster()->MoveLand(POINT_LAND, LandingPos, me->GetSpeed(MOVE_RUN) * 1.75f);
                         break;
                     case POINT_LAND:
-                        me->SendMovementSetSplineAnim(Movement::AnimType::ToGround);
                         me->SetDisableGravity(false);
                         me->SetHover(false);
-                        me->SendMovementSetSplineAnim(Movement::AnimType::ToGround);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetReactState(REACT_AGGRESSIVE);
 
                         if (Unit* nearTarget = me->SelectNearestTarget(100.0f))
@@ -360,7 +358,6 @@ class npc_drahga_valiona : public CreatureScript
                     me->RemoveAurasDueToSpell(SPELL_RIDE_VEHICLE);
                     me->SetDisableGravity(true);
                     me->SetHover(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
 
                     Position pos;
                     pos.Relocate(me);

--- a/src/server/scripts/EasternKingdoms/GrimBatol/grim_batol.cpp
+++ b/src/server/scripts/EasternKingdoms/GrimBatol/grim_batol.cpp
@@ -184,7 +184,9 @@ struct npc_grim_batol_battered_red_drake: public VehicleAI
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
             me->RemoveAurasDueToSpell(SPELL_NET);
             DoCastSelf(SPELL_BOMBING_RUN_PROTECTION_TRIGGER);
-            me->SetDisableGravity(true); // Todo: do not update the anim tier here
+
+            // Yes, this is stupid. Don't argue. Confirmed by 2012 sniffs.
+            me->SetDisableGravity(true, false, false);
             summon->CastSpell(summon, SPELL_NET_SCRIPT);
             summon->DespawnOrUnsummon(3s);
         }
@@ -217,7 +219,8 @@ struct npc_grim_batol_battered_red_drake: public VehicleAI
             _instance->SetData(DATA_START_BATTERED_RED_DRAKE_DESPAWN_EVENT, IN_PROGRESS);
             me->SetControlled(true, UNIT_STATE_ROOT);
             me->PlayOneShotAnimKitId(ANIM_KIT_ID_LIFTOFF);
-            // Todo: set anim tier to fly here
+            me->SetAnimationTier(AnimationTier::Fly);
+
             player->SetMover(me);
             _playerGuid = player->GetGUID();
 
@@ -245,6 +248,7 @@ struct npc_grim_batol_battered_red_drake: public VehicleAI
                 case EVENT_SET_HOVERING:
                     if (Player* player = ObjectAccessor::FindConnectedPlayer(_playerGuid))
                         DoCast(player, SPELL_GEAR_SCALING_TRIGGER, true);
+
                     break;
                 case EVENT_PREPARE_BOMBARDMENT:
                     if (Player* player = ObjectAccessor::FindConnectedPlayer(_playerGuid))

--- a/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
+++ b/src/server/scripts/EasternKingdoms/Karazhan/boss_nightbane.cpp
@@ -211,7 +211,7 @@ public:
                 switch (pointId)
                 {
                     case POINT_INTRO_START:
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_STAND_STATE, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                        me->SetStandState(UNIT_STAND_STATE_STAND);
                         events.ScheduleEvent(EVENT_START_INTRO_PATH, Milliseconds(1));
                         break;
                     case POINT_INTRO_END:

--- a/src/server/scripts/Kalimdor/CavernsOfTime/DragonSoul/boss_madness_of_deathwing.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/DragonSoul/boss_madness_of_deathwing.cpp
@@ -1355,10 +1355,8 @@ struct npc_madness_of_deathwing_thrall : public ScriptedAI
                 break;
             case ACTION_FIRE_DRAGON_SOUL:
                 _events.Reset();
-                me->SendMovementSetSplineAnim(Movement::AnimType::FlyToGround);
                 me->SetDisableGravity(true);
                 me->SendSetPlayHoverAnim(true);
-                me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 DoCastAOE(SPELL_FIRE_DRAGON_SOUL_ASPECTS);
                 DoCastAOE(SPELL_TRIGGER_ASPECT_YELL);
                 DoCastSelf(SPELL_ASTRAL_RECALL_OUTRO);
@@ -1394,9 +1392,7 @@ struct npc_madness_of_deathwing_thrall : public ScriptedAI
                     break;
                 case EVENT_PLAY_MOVIE:
                     DoCastAOE(SPELL_PLAY_MOVIE);
-                    me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     me->SetFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
-                    me->SendMovementSetSplineAnim(Movement::AnimType::ToGround);
                     me->SendSetPlayHoverAnim(false);
                     me->SetDisableGravity(false);
 
@@ -2184,14 +2180,14 @@ class spell_madness_of_deathwing_concentration : public AuraScript
                 if (creature->IsAIEnabled)
                     creature->AI()->SetGUID(GetTarget()->GetGUID(), DATA_FOCUSED_LIMB);
 
-        GetTarget()->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+        GetTarget()->SetDisableGravity(true);
         for (uint8 i = 0; i < 2; ++i)
             GetTarget()->CastSpell(GetTarget(), SPELL_SUMMON_COSMETIC_TENTACLE);
     }
 
     void AfterRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
-        GetTarget()->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+        GetTarget()->SetDisableGravity(false);
     }
 
     void Register() override

--- a/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
@@ -230,7 +230,6 @@ public:
                     case 9:
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         if (Creature* trigger = ObjectAccessor::GetCreature(*me, triggerGUID))
                             me->Kill(trigger);
                         me->SetReactState(REACT_AGGRESSIVE);
@@ -248,7 +247,6 @@ public:
                     case 10:
                         me->SetCanFly(true);
                         me->SetDisableGravity(true);
-                        me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetFacingTo(me->GetOrientation() + float(M_PI));
                         if (Creature * trigger = me->SummonCreature(NPC_TRIGGER, MiddleRoomLocation, TEMPSUMMON_CORPSE_DESPAWN))
                             triggerGUID = trigger->GetGUID();

--- a/src/server/scripts/Kalimdor/VortexPinnacle/boss_altairus.cpp
+++ b/src/server/scripts/Kalimdor/VortexPinnacle/boss_altairus.cpp
@@ -104,7 +104,6 @@ struct boss_altairus : public BossAI
     boss_altairus(Creature* creature) : BossAI(creature, DATA_ALTAIRUS)
     {
         me->SetHover(true);
-        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
     }
 
     void JustEngagedWith(Unit* /*target*/) override

--- a/src/server/scripts/Kalimdor/VortexPinnacle/vortex_pinnacle.cpp
+++ b/src/server/scripts/Kalimdor/VortexPinnacle/vortex_pinnacle.cpp
@@ -226,23 +226,23 @@ struct npc_slipstream : public NullCreatureAI
         {
             switch (effect->GetSpellInfo()->Id)
             {
-            case SPELL_SLIPSTREAM_CONTROL_VEHICLE_FIRST:
-                DoCast(who, SPELL_SLIPSTREAM_SECOND);
-                break;
-            case SPELL_SLIPSTREAM_CONTROL_VEHICLE_SECOND:
-                if (_instance->GetGuidData(DATA_SLIPSTREAM_ERTAN_3) == _guid)
+                case SPELL_SLIPSTREAM_CONTROL_VEHICLE_FIRST:
+                    DoCast(who, SPELL_SLIPSTREAM_SECOND);
+                    break;
+                case SPELL_SLIPSTREAM_CONTROL_VEHICLE_SECOND:
+                    if (_instance->GetGuidData(DATA_SLIPSTREAM_ERTAN_3) == _guid)
+                        DoCast(who, SPELL_SLIPSTREAM_LAST);
+                    else
+                        DoCast(who, SPELL_SLIPSTREAM_THIRD);
+                    break;
+                case SPELL_SLIPSTREAM_CONTROL_VEHICLE_THIRD:
+                    DoCast(who, SPELL_SLIPSTREAM_FOURTH);
+                    break;
+                case SPELL_SLIPSTREAM_CONTROL_VEHICLE_FOURTH:
                     DoCast(who, SPELL_SLIPSTREAM_LAST);
-                else
-                    DoCast(who, SPELL_SLIPSTREAM_THIRD);
-                break;
-            case SPELL_SLIPSTREAM_CONTROL_VEHICLE_THIRD:
-                DoCast(who, SPELL_SLIPSTREAM_FOURTH);
-                break;
-            case SPELL_SLIPSTREAM_CONTROL_VEHICLE_FOURTH:
-                DoCast(who, SPELL_SLIPSTREAM_LAST);
-                break;
-            default:
-                break;
+                    break;
+                default:
+                    break;
             }
         }
     }
@@ -274,11 +274,11 @@ struct npc_slipstream_landing_zone : public ScriptedAI
         {
             switch (eventId)
             {
-            case EVENT_EJECT_ALL_PASSENGERS:
-                DoCast(me, SPELL_GENERIC_EJECT_ALL_PASSENGERS);
-                break;
-            default:
-                break;
+                case EVENT_EJECT_ALL_PASSENGERS:
+                    DoCast(me, SPELL_GENERIC_EJECT_ALL_PASSENGERS);
+                    break;
+                default:
+                    break;
             }
         }
     }
@@ -302,8 +302,6 @@ struct npc_vp_young_storm_dragon : public ScriptedAI
     {
         _EnterEvadeMode();
         me->SetHover(false);
-        me->SendMovementSetSplineAnim(Movement::AnimType::ToGround);
-        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
         ScriptedAI::EnterEvadeMode(why);
     }
 
@@ -329,29 +327,27 @@ struct npc_vp_young_storm_dragon : public ScriptedAI
         {
             switch (eventId)
             {
-            case EVENT_TAKEOFF:
-            {
-                me->SendMovementSetSplineAnim(Movement::AnimType::ToFly);
-                me->SetHover(true);
-                me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
-                _events.ScheduleEvent(EVENT_ATTACK, 3s);
-                break;
-            }
-            case EVENT_ATTACK:
-                me->SetReactState(REACT_AGGRESSIVE);
-                _events.RescheduleEvent(EVENT_CHILLING_BLAST, 14s);
-                _events.RescheduleEvent(EVENT_HEALING_WELL, 15s);
-                break;
-            case EVENT_CHILLING_BLAST:
-                DoCastVictim(SPELL_CHILLING_BLAST);
-                _events.Repeat(14s);
-                break;
-            case EVENT_HEALING_WELL:
-                DoCast(me, SPELL_HEALING_WELL);
-                _events.Repeat(15s);
-                break;
-            default:
-                break;
+                case EVENT_TAKEOFF:
+                {
+                    me->SetHover(true);
+                    _events.ScheduleEvent(EVENT_ATTACK, 3s);
+                    break;
+                }
+                case EVENT_ATTACK:
+                    me->SetReactState(REACT_AGGRESSIVE);
+                    _events.RescheduleEvent(EVENT_CHILLING_BLAST, 14s);
+                    _events.RescheduleEvent(EVENT_HEALING_WELL, 15s);
+                    break;
+                case EVENT_CHILLING_BLAST:
+                    DoCastVictim(SPELL_CHILLING_BLAST);
+                    _events.Repeat(14s);
+                    break;
+                case EVENT_HEALING_WELL:
+                    DoCast(me, SPELL_HEALING_WELL);
+                    _events.Repeat(15s);
+                    break;
+                default:
+                    break;
             }
         }
 

--- a/src/server/scripts/Maelstrom/Stonecore/boss_slabhide.cpp
+++ b/src/server/scripts/Maelstrom/Stonecore/boss_slabhide.cpp
@@ -129,7 +129,6 @@ class boss_slabhide : public CreatureScript
                 {
                     me->SetCanFly(false);
                     me->SetDisableGravity(false);
-                    me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 }
                 else
                 {
@@ -137,7 +136,6 @@ class boss_slabhide : public CreatureScript
                     me->setActive(true);
                     me->SetCanFly(true);
                     me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     me->SetReactState(REACT_PASSIVE);
                     events.SetPhase(PHASE_INTRO);
                 }
@@ -204,7 +202,6 @@ class boss_slabhide : public CreatureScript
                     case POINT_SLABHIDE_INTRO_LAND:
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetHover(false);
                         me->SetHomePosition(SlabhideIntroLandPos);
                         me->HandleEmoteCommand(EMOTE_ONESHOT_ROAR);
@@ -215,7 +212,6 @@ class boss_slabhide : public CreatureScript
                         _isFlying = true;
                         me->SetCanFly(true);
                         me->SetDisableGravity(true);
-                        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetHover(true);
                         me->GetMotionMaster()->MoveTakeoff(POINT_SLABHIDE_IN_AIR, SlabhideInAirPos);
                         break;
@@ -226,7 +222,6 @@ class boss_slabhide : public CreatureScript
                         _isFlying = false;
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetHover(false);
                         DoCast(me, SPELL_COOLDOWN_5S);
                         events.ScheduleEvent(EVENT_ATTACK, Seconds(1) + Milliseconds(200));

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_saviana_ragefire.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_saviana_ragefire.cpp
@@ -119,7 +119,6 @@ class boss_saviana_ragefire : public CreatureScript
                     case POINT_LAND_GROUND:
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetReactState(REACT_AGGRESSIVE);
                         events.ScheduleEvent(EVENT_ENRAGE, Seconds(1), EVENT_GROUP_LAND_PHASE);
                         events.ScheduleEvent(EVENT_FLAME_BREATH, Seconds(2), Seconds(4), EVENT_GROUP_LAND_PHASE);
@@ -162,7 +161,6 @@ class boss_saviana_ragefire : public CreatureScript
                         {
                             me->SetCanFly(true);
                             me->SetDisableGravity(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                             me->SetReactState(REACT_PASSIVE);
                             me->AttackStop();
                             Position pos;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
@@ -226,7 +226,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
             void JustReachedHome() override
             {
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND);
                 me->SetReactState(REACT_AGGRESSIVE);
                 _JustReachedHome();
                 Talk(SAY_WIPE);
@@ -276,7 +275,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
                         break;
                     case POINT_GROUND:
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND);
                         me->SetReactState(REACT_AGGRESSIVE);
                         if (Unit* victim = me->SelectVictim())
                             AttackStart(victim);
@@ -352,7 +350,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                             break;
                         }
                         case EVENT_DELIRIOUS_SLASH:
-                            if (_offtankGUID && !me->HasByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER))
+                            if (_offtankGUID && me->GetAnimationTier() != AnimationTier::Fly)
                                 if (Player* _offtank = ObjectAccessor::GetPlayer(*me, _offtankGUID))
                                     DoCast(_offtank, SPELL_DELIRIOUS_SLASH);
                             events.ScheduleEvent(EVENT_DELIRIOUS_SLASH, urand(20000, 24000), EVENT_GROUP_NORMAL);
@@ -400,7 +398,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
                             break;
                         case EVENT_AIR_START_FLYING:
                             me->SetDisableGravity(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND);
                             me->GetMotionMaster()->MovePoint(POINT_AIR, airPos);
                             break;
                         case EVENT_AIR_FLY_DOWN:

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -323,7 +323,6 @@ class boss_sindragosa : public CreatureScript
                     me->SetFarVisible(true);
                     me->SetCanFly(true);
                     me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     me->SetSpeedRate(MOVE_FLIGHT, 4.0f);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     float moveTime = me->GetExactDist(&SindragosaFlyPos) / (me->GetSpeed(MOVE_FLIGHT) * 0.001f);
@@ -358,7 +357,6 @@ class boss_sindragosa : public CreatureScript
                         me->SetFarVisible(true);
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetHomePosition(SindragosaLandPos);
                         me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                         me->SetSpeedRate(MOVE_FLIGHT, 2.5f);
@@ -386,7 +384,6 @@ class boss_sindragosa : public CreatureScript
                     {
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetReactState(REACT_DEFENSIVE);
                         if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == POINT_MOTION_TYPE)
                             me->GetMotionMaster()->MovementExpired();
@@ -491,7 +488,6 @@ class boss_sindragosa : public CreatureScript
                             Talk(SAY_AIR_PHASE);
                             me->SetCanFly(true);
                             me->SetDisableGravity(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                             me->SetReactState(REACT_PASSIVE);
                             me->AttackStop();
                             Position pos;
@@ -732,7 +728,6 @@ class npc_spinestalker : public CreatureScript
                 me->SetFarVisible(true);
                 me->SetCanFly(false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 me->SetHomePosition(SpinestalkerLandPos);
                 me->SetFacingTo(SpinestalkerLandPos.GetOrientation());
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
@@ -871,7 +866,6 @@ class npc_rimefang : public CreatureScript
                 me->SetFarVisible(true);
                 me->SetCanFly(false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 me->SetHomePosition(RimefangLandPos);
                 me->SetFacingTo(RimefangLandPos.GetOrientation());
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -529,7 +529,6 @@ class boss_the_lich_king : public CreatureScript
                 _JustDied();
                 DoCastAOE(SPELL_PLAY_MOVIE, false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 me->GetMotionMaster()->MoveFall();
                 if (Creature* frostmourne = me->FindNearestCreature(NPC_FROSTMOURNE_TRIGGER, 50.0f))
                     frostmourne->DespawnOrUnsummon();
@@ -1105,7 +1104,6 @@ class boss_the_lich_king : public CreatureScript
                             sCreatureTextMgr->SendSound(me, SOUND_PAIN, CreatureTextSoundType::DirectSound, CHAT_MSG_MONSTER_YELL, 0, TEXT_RANGE_NORMAL, TEAM_OTHER, false);
                             // set flight
                             me->SetDisableGravity(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                             me->GetMotionMaster()->MovePoint(POINT_LK_OUTRO_2, OutroFlying);
                             break;
                         case EVENT_OUTRO_TALK_7:

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -375,7 +375,6 @@ public:
             Initialize();
 
             me->SetDisableGravity(true);
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC);
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
             // TO DO: find what in core is making boss slower than in retail (when correct speed data) or find missing movement flag update or forced spline change

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -614,7 +614,7 @@ class boss_mimiron : public CreatureScript
                                 if (Creature* aerial = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_AERIAL_COMMAND_UNIT)))
                                 {
                                     aerial->GetMotionMaster()->MoveLand(0, (aerial->GetPositionX(), aerial->GetPositionY(), aerial->GetPositionZ()));
-                                    aerial->SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, 0);
+
                                     aerial->CastSpell(vx001, SPELL_MOUNT_VX_001);
                                     aerial->CastSpell(aerial, SPELL_HALF_HEAL);
                                 }
@@ -984,7 +984,7 @@ class boss_vx_001 : public CreatureScript
                         me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_IMMUNE_TO_PC);
                         me->RemoveAurasDueToSpell(SPELL_FREEZE_ANIM);
                         me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_NONE); // Remove emotestate.
-                        //me->SetUInt32Value(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER); Blizzard handles hover animation like this it seems.
+                        //me->SetHover(true); // Blizzard handles hover animation like this it seems.
                         DoCast(me, SPELL_HEAT_WAVE_AURA);
 
                         events.SetPhase(PHASE_VX_001);

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/utgarde_keep.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardeKeep/utgarde_keep.cpp
@@ -283,7 +283,7 @@ class npc_enslaved_proto_drake : public CreatureScript
             {
                 if (type == WAYPOINT_MOTION_TYPE && id == POINT_LAST)
                 {
-                    me->RemoveByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                    me->SetAnimationTier(AnimationTier::Ground);
                 }
             }
 
@@ -292,7 +292,7 @@ class npc_enslaved_proto_drake : public CreatureScript
                 if (type == TYPE_PROTODRAKE_AT && data == DATA_PROTODRAKE_MOVE && !_setData && me->GetDistance(protodrakeCheckPos) < 5.0f)
                 {
                     _setData = true;
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                    me->SetAnimationTier(AnimationTier::Fly);
                     me->GetMotionMaster()->MovePath(PATH_PROTODRAKE, false);
                 }
             }

--- a/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
+++ b/src/server/scripts/Northrend/UtgardeKeep/UtgardePinnacle/boss_skadi.cpp
@@ -367,7 +367,6 @@ public:
             me->SetFarVisible(true);
             me->SetCanFly(true);
             me->SetDisableGravity(true);
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
 
             _scheduler.Schedule(Seconds(2), [this](TaskContext /*context*/)
             {


### PR DESCRIPTION
**Changes proposed**: Fixed animation tier handling.

For reference in reviewing:

```cpp
AnimType::ToGround = AnimationTier::Ground
AnimType::ToFly = AnimationTier::Hover
AnimType::FlyToFly = AnimationTier::Swim
AnimType::FlyToGround = AnimationTier::Fly
nil = AnimationTier::Submerged

UNIT_BYTE1_FLAG_ALWAYS_STAND    = 1,
UNIT_BYTE1_FLAG_HOVER           = 2,
UNIT_BYTE1_FLAG_UNK_3           = 4,
Combine these flags to obtain the corresponding AnimationTier values
```
===

  * Theralion & Valiona
```cpp
me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
```
Is equivalent to removing `AnimationTier::Fly`, which is now implicitely set by `Unit::SetDisableGravity(false)`.

```cpp
me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
```
Is equivalent to setting `AnimationTier::Fly`, which is now implicitely set by `Unit::SetDisableGravity(true)`.

* Nefarian

```cpp
me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
```

Is replaced by `me->SetAnimationTier(AnimationTier::Fly);`. There is some contention here; the call is done manually to avoid sending splines, but I believe it is related to Nefarian actually sending splines; but that happens before he appears to the client, causing the backend to stop packets from going out.

If we choose to revert to using the spline variant, the patch becomes
```diff
-            me->AddUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
-            me->SetAnimationTier(AnimationTier::Fly);
+           me->SetDisableGravity(true);
```

* Valiona (Dragha Shadowburner)

Valiona here alternates between flying and hover. This one needs special care:
```cpp
            void IsSummonedBy(Unit* /*summon*/) override
            {
                me->SetDisableGravity(true);
                me->SetHover(true)
                ....
            }
```
`SetDiasableGravity` sets the animation tier to `Fly`. `SetHover`, however, will not change it, because `Fly` has priority over `Hover`. Yet the script continuously sets hover manually. This feels like a script-specific issue as I've only spotted it here. Alternatively, we could set the `Fly` animation tier if the unit is not hovering, but that introduces a dependency on the order of function calls. We **need** to adress this.

Moreover, when Valiona lands, we observe two animation tier updates in sniffs, which coincide with what the code now does.

* Nightbane

This was straight up bogus parameters being mixed together and resulting in correct visuals. Now fixed.
