### PR TITLE
Tools/mmaps_generator: Fixed brackets

### DIFF
--- a/src/tools/mmaps_generator/TerrainBuilder.cpp
+++ b/src/tools/mmaps_generator/TerrainBuilder.cpp
@@ -739,48 +739,48 @@ namespace MMAP
                         {
                             for (uint32 y = 0; y < vertsY; ++y)
                             {
+                                vert = G3D::Vector3(corner.x + x * GRID_PART_SIZE, corner.y + y * GRID_PART_SIZE, data[y * vertsX + x]);
+                                vert = vert * rotation * scale + position;
+                                vert.x *= -1.f;
+                                vert.y *= -1.f;
+                                liqVerts.push_back(vert);
+                            }
+                        }
+
+                        int idx1, idx2, idx3, idx4;
+                        uint32 square;
+                        for (uint32 x = 0; x < tilesX; ++x)
+                        {
+                            for (uint32 y = 0; y < tilesY; ++y)
+                            {
+                                if ((flags[x + y * tilesX] & 0x0f) != 0x0f)
                                 {
-                                    vert = G3D::Vector3(corner.x + x * GRID_PART_SIZE, corner.y + y * GRID_PART_SIZE, data[y * vertsX + x]);
-                                    vert = vert * rotation * scale + position;
-                                    vert.x *= -1.f;
-                                    vert.y *= -1.f;
-                                    liqVerts.push_back(vert);
-                                }
+                                    square = x * tilesY + y;
+                                    idx1 = square + x;
+                                    idx2 = square + 1 + x;
+                                    idx3 = square + tilesY + 1 + 1 + x;
+                                    idx4 = square + tilesY + 1 + x;
 
-                                int idx1, idx2, idx3, idx4;
-                                uint32 square;
-                                for (uint32 x = 0; x < tilesX; ++x)
-                                {
-                                    for (uint32 y = 0; y < tilesY; ++y)
-                                        if ((flags[x + y * tilesX] & 0x0f) != 0x0f)
-                                        {
-                                            square = x * tilesY + y;
-                                            idx1 = square + x;
-                                            idx2 = square + 1 + x;
-                                            idx3 = square + tilesY + 1 + 1 + x;
-                                            idx4 = square + tilesY + 1 + x;
-
-                                            // top triangle
-                                            liqTris.push_back(idx3);
-                                            liqTris.push_back(idx2);
-                                            liqTris.push_back(idx1);
-                                            // bottom triangle
-                                            liqTris.push_back(idx4);
-                                            liqTris.push_back(idx3);
-                                            liqTris.push_back(idx1);
-                                        }
-                                }
-
-                                uint32 liqOffset = meshData.liquidVerts.size() / 3;
-                                for (uint32 j = 0; j < liqVerts.size(); ++j)
-                                    meshData.liquidVerts.append(liqVerts[j].y, liqVerts[j].z, liqVerts[j].x);
-
-                                for (uint32 j = 0; j < liqTris.size() / 3; ++j)
-                                {
-                                    meshData.liquidTris.append(liqTris[j * 3 + 1] + liqOffset, liqTris[j * 3 + 2] + liqOffset, liqTris[j * 3] + liqOffset);
-                                    meshData.liquidType.append(type);
+                                    // top triangle
+                                    liqTris.push_back(idx3);
+                                    liqTris.push_back(idx2);
+                                    liqTris.push_back(idx1);
+                                    // bottom triangle
+                                    liqTris.push_back(idx4);
+                                    liqTris.push_back(idx3);
+                                    liqTris.push_back(idx1);
                                 }
                             }
+                        }
+
+                        uint32 liqOffset = meshData.liquidVerts.size() / 3;
+                        for (uint32 j = 0; j < liqVerts.size(); ++j)
+                            meshData.liquidVerts.append(liqVerts[j].y, liqVerts[j].z, liqVerts[j].x);
+
+                        for (uint32 j = 0; j < liqTris.size() / 3; ++j)
+                        {
+                            meshData.liquidTris.append(liqTris[j * 3 + 1] + liqOffset, liqTris[j * 3 + 2] + liqOffset, liqTris[j * 3] + liqOffset);
+                            meshData.liquidType.append(type);
                         }
                     }
                 }


### PR DESCRIPTION
**Changes proposed**:

- Added back some brackets that were removed in https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/187d537fbac8e17a89145aba2b42c2419b5c9ec2, causing the mmaps_generator to slow down to a crawl. The function now matches its 3.3.5/master counterpart.

**Tests performed**: (Does it build, tested in-game, etc)
Compiles, generating new MMaps no longer causes the mmaps_generator to be stuck at 10% for hours.
