### PR TITLE
Fix null pointer exception in ConnectionPatcher

### DIFF
--- a/src/tools/connection_patcher/Program.cpp
+++ b/src/tools/connection_patcher/Program.cpp
@@ -252,9 +252,11 @@ int main(int argc, char** argv)
         std::string const binary_path(argv[1]);
         std::string renamed_binary_path(binary_path);
 
-        wchar_t* commonAppData(nullptr);
 #ifdef _WIN32
+        wchar_t* commonAppData(nullptr);
         SHGetKnownFolderPath(FOLDERID_ProgramData, 0, nullptr, &commonAppData);
+#else
+        const wchar_t* commonAppData(L".");
 #endif
 
         std::cout << "Creating patched binary..." << std::endl;


### PR DESCRIPTION
**Changes proposed**:
- Make sure the variable ```commonAppData``` is never set to null, I've currently implemented this by setting the 'AppData' folder to the current working directory on any system that does not define ```_WIN32```.

**Issues addressed**: Fixes #177

**Tests performed**: 
I have confirmed that the code still compiles and runs on my Ubuntu 20.04 server, and that using the patcher to patch the original client binary does not cause the exception described in issue #177 anymore. The patched client also still works properly after using the patcher.

**Known issues and TODO list**:
- None so far
