### PR TITLE
Core: Fixed compilations error in debug mode.

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -272,7 +272,7 @@ TransactionCallback DatabaseWorkerPool<T>::AsyncCommitTransaction(SQLTransaction
     {
         case 0:
             TC_LOG_DEBUG("sql.driver", "Transaction contains 0 queries. Not executing.");
-            return;
+            break;
         case 1:
             TC_LOG_DEBUG("sql.driver", "Warning: Transaction only holds 1 query, consider removing Transaction context in code.");
             break;

--- a/src/server/database/Database/Field.cpp
+++ b/src/server/database/Database/Field.cpp
@@ -37,8 +37,7 @@ uint8 Field::GetUInt8() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Int8))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetUInt8() on non-tinyint field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0;
     }
 #endif
@@ -56,8 +55,7 @@ int8 Field::GetInt8() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Int8))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetInt8() on non-tinyint field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0;
     }
 #endif
@@ -75,8 +73,7 @@ uint16 Field::GetUInt16() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Int16))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetUInt16() on non-smallint field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0;
     }
 #endif
@@ -94,8 +91,7 @@ int16 Field::GetInt16() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Int16))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetInt16() on non-smallint field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0;
     }
 #endif
@@ -113,8 +109,7 @@ uint32 Field::GetUInt32() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Int32))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetUInt32() on non-(medium)int field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0;
     }
 #endif
@@ -132,8 +127,7 @@ int32 Field::GetInt32() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Int32))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetInt32() on non-(medium)int field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0;
     }
 #endif
@@ -151,8 +145,7 @@ uint64 Field::GetUInt64() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Int64))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetUInt64() on non-bigint field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0;
     }
 #endif
@@ -170,8 +163,7 @@ int64 Field::GetInt64() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Int64))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetInt64() on non-bigint field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0;
     }
 #endif
@@ -189,8 +181,7 @@ float Field::GetFloat() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Float))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetFloat() on non-float field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0.0f;
     }
 #endif
@@ -208,8 +199,7 @@ double Field::GetDouble() const
 #ifdef TRINITY_DEBUG
     if (!IsType(DatabaseFieldTypes::Double) && !IsType(DatabaseFieldTypes::Decimal))
     {
-        TC_LOG_WARN("sql.sql", "Warning: GetDouble() on non-double/non-decimal field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return 0.0f;
     }
 #endif
@@ -227,8 +217,7 @@ char const* Field::GetCString() const
 #ifdef TRINITY_DEBUG
     if (IsNumeric() && data.raw)
     {
-        TC_LOG_WARN("sql.sql", "Error: GetCString() on numeric field %s.%s (%s.%s) at index %u. Using type: %s.",
-            meta.TableAlias, meta.Alias, meta.TableName, meta.Name, meta.Index, meta.Type);
+        LogWrongType(__FUNCTION__);
         return nullptr;
     }
 #endif


### PR DESCRIPTION
While compiling in debug mode these errors appear preventing any compilations.

Field.cpp
```
Severity	Code	Description	Project	File	Line	Suppression State
Error	C2228	left of '.TableAlias' must have class/struct/union database	...\Database\Field.cpp	41
```
Fixed using TrinityCore [Reference](https://github.com/TrinityCore/TrinityCore/blob/1c52d5fff738aa01bd27fd117076ac33515acef5/src/server/database/Database/Field.cpp)

DatabaseWorkerPool.cpp
```
Severity	Code	Description	Project	File	Line	Suppression State
Error	C2561	'DatabaseWorkerPool<LoginDatabaseConnection>::AsyncCommitTransaction': function must return a value	database	...\Database\DatabaseWorkerPool.cpp	275	
```
No TrinityCore Reference for this one, It seems that they have the same issue. It shouldn't return anything. Instead, I replaced the return with a break


How-To Reproduce:
In CMake Configuration.
1. Scroll to With Tab
2. Check WITH_COREDEBUG & WITH_WARNINGS options
3. Rebuild Solution

![image](https://user-images.githubusercontent.com/2213079/100536145-26bd8500-3227-11eb-8c00-58645b8f1530.png)

Environment:
Windows: V1909 Build 18363.1198
CMake: 3.18.0
VS: 16.8.2
Boost: 1_72.0