### PR TITLE
Core/Auras: vehicles should not despawn during seat change

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3083,7 +3083,10 @@ void AuraEffect::HandleAuraControlVehicle(AuraApplication const* aurApp, uint8 m
                 caster->ToCreature()->RemoveCorpse();
         }
 
-        if (!(mode & AURA_EFFECT_HANDLE_CHANGE_AMOUNT))
+        bool seatChange = (mode & AURA_EFFECT_HANDLE_CHANGE_AMOUNT)                             // Seat change on the same direct vehicle
+            || target->HasAuraTypeWithCaster(SPELL_AURA_CONTROL_VEHICLE, caster->GetGUID());    // Seat change to a proxy vehicle (for example turret mounted on a siege engine)
+
+        if (!seatChange)
             caster->_ExitVehicle();
         else
             target->GetVehicleKit()->RemovePassenger(caster);  // Only remove passenger from vehicle without launching exit movement or despawning the vehicle


### PR DESCRIPTION
**Changes proposed**:

- Vehicles are despawned while Seat Changes. Some tests and with a big help from Shauren (https://gist.github.com/Shauren/a5a7ebf7f0004ca1dbb8e0aac283bebb) its works now. My change was that at the check only considered auras from caster and not all on the vehicle(without this, that broke some other things(eject from vehicle, despawn vehicle accessory if more as one Vehicle ride spell on the vehicle)
-  look at https://github.com/TrinityCore/TrinityCore/pull/25772
- 

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)
build and test with different vehicle ride spells for seat change.

**Known issues and TODO list**:

- [ ] 
- [ ] 
