### PR TITLE
Fix hunter and shaman trainer spell.

### DIFF
--- a/sql/updates/world/4.3.4/2021_01_23_00_world.sql
+++ b/sql/updates/world/4.3.4/2021_01_23_00_world.sql
@@ -3,4 +3,4 @@ UPDATE `trainer_spell` SET `SpellID` = 86528 WHERE `TrainerID` = 40 AND `SpellId
 UPDATE `trainer_spell` SET `SpellID` = 93321 WHERE `TrainerID` = 40 AND `SpellId` = 79682;
 
 -- Correct shaman spell trainer
-UPDATE `trainer_spell` SET `SpellID` = 87507 WHERE `TrainerID` = 124 AND `SpellId` = 86529;
+UPDATE `trainer_spell` SET `SpellID` = 86529 WHERE `TrainerID` = 124 AND `SpellId` = 87507;

--- a/sql/updates/world/4.3.4/2021_01_23_00_world.sql
+++ b/sql/updates/world/4.3.4/2021_01_23_00_world.sql
@@ -1,6 +1,6 @@
 -- Correct hunter spell trainer
 UPDATE `trainer_spell` SET `SpellID` = 86528 WHERE `TrainerID` = 40 AND `SpellId` = 87506;
-UPDATE `trainer_spell` SET `SpellID` = 79682 WHERE `TrainerID` = 40 AND `SpellId` = 93321;
+UPDATE `trainer_spell` SET `SpellID` = 93321 WHERE `TrainerID` = 40 AND `SpellId` = 79682;
 
 -- Correct shaman spell trainer
 UPDATE `trainer_spell` SET `SpellID` = 87507 WHERE `TrainerID` = 124 AND `SpellId` = 86529;

--- a/sql/updates/world/4.3.4/2021_01_23_00_world.sql
+++ b/sql/updates/world/4.3.4/2021_01_23_00_world.sql
@@ -1,0 +1,6 @@
+-- Correct hunter spell trainer
+UPDATE `trainer_spell` SET `SpellID` = 86528 WHERE `TrainerID` = 40 AND `SpellId` = 87506;
+UPDATE `trainer_spell` SET `SpellID` = 79682 WHERE `TrainerID` = 40 AND `SpellId` = 93321;
+
+-- Correct shaman spell trainer
+UPDATE `trainer_spell` SET `SpellID` = 87507 WHERE `TrainerID` = 124 AND `SpellId` = 86529;


### PR DESCRIPTION
**Changes proposed**:

- Spell Control Pet from trainer not working, changed to [spell ID 93321](https://www.wowhead.com/spell=93321/control-pet)
- Spell Mail Specialization of Hunter from trainer not match with client
- Spell Mail Specialization of Shaman from trainer not match with client

**Issues addressed**: None

**Tests performed**: Tested in game
