### PR TITLE
Core/Vehicle: add function to Skip Cut Scenes etc.

### DIFF
--- a/src/server/game/AI/CreatureAI.h
+++ b/src/server/game/AI/CreatureAI.h
@@ -224,6 +224,8 @@ class TC_GAME_API CreatureAI : public UnitAI
 
         virtual void PassengerBoarded(Unit* /*passenger*/, int8 /*seatId*/, bool /*apply*/) { }
 
+        virtual void PassengerRequestExit(Unit* /*passenger*/) { }
+
         virtual void OnSpellClick(Unit* /*clicker*/, bool& /*result*/) { }
 
         virtual bool CanSeeAlways(WorldObject const* /*obj*/) { return false; }

--- a/src/server/game/Handlers/VehicleHandler.cpp
+++ b/src/server/game/Handlers/VehicleHandler.cpp
@@ -208,7 +208,12 @@ void WorldSession::HandleRequestVehicleExit(WorldPacket& /*recvData*/)
         if (VehicleSeatEntry const* seat = vehicle->GetSeatForPassenger(GetPlayer()))
         {
             if (seat->CanEnterOrExit())
+            {
                 GetPlayer()->ExitVehicle();
+                if (Creature* creature = vehicle->GetBase()->ToCreature())
+                    if (creature->IsAIEnabled)
+                        creature->AI()->PassengerRequestExit(GetPlayer());
+            }
             else
                 TC_LOG_ERROR("network", "Player %u tried to exit vehicle, but seatflags %u (ID: %u) don't permit that.",
                 GetPlayer()->GetGUID().GetCounter(), seat->ID, seat->Flags);


### PR DESCRIPTION
**Changes proposed**:

- Cut Scenes etc. on Vehicles can be skipped by press the exit button. Yes we have the function `PassengerBoarded` with the boolean `apply` that was `false` if player leave the vehicle but the problem here: `apply` is also `false` if it only a seat change and without more and more checks is it not realy easy to determine if it only a seat change or leaving the vehicle.
- This new function will only called if player can successfully leave the vehicle with the exit button and we have a easy way to handle skipped cut scenes or other.
- 

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)
Build and works ingame
**Known issues and TODO list**:

- [ ] 
- [ ] 
