### PR TITLE
Core/Vehicle: Add IsControllableVehicle check and correct CharmedBy Assert call to fix a crash

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11843,7 +11843,7 @@ bool Unit::SetCharmedBy(Unit* charmer, CharmType type, AuraApplication const* au
         charmer->RemoveAurasByType(SPELL_AURA_MOUNTED);
 
     ASSERT(type != CHARM_TYPE_POSSESS || charmer->GetTypeId() == TYPEID_PLAYER);
-    ASSERT((type == CHARM_TYPE_VEHICLE) == IsVehicle());
+ASSERT((type == CHARM_TYPE_VEHICLE) == (GetVehicleKit() && GetVehicleKit()->IsControllableVehicle()));
 
     TC_LOG_DEBUG("entities.unit", "SetCharmedBy: charmer %u (GUID %u), charmed %u (GUID %u), type %u.", charmer->GetEntry(), charmer->GetGUID().GetCounter(), GetEntry(), GetGUID().GetCounter(), uint32(type));
 

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -626,6 +626,15 @@ bool Vehicle::IsVehicleInUse() const
     return false;
 }
 
+bool Vehicle::IsControllableVehicle() const
+{
+    for (SeatMap::const_iterator itr = Seats.begin(); itr != Seats.end(); ++itr)
+        if (itr->second.SeatInfo->HasFlag(VEHICLE_SEAT_FLAG_CAN_CONTROL))
+            return true;
+
+    return false;
+}
+
 /**
  * @fn void Vehicle::InitMovementInfoForBase()
  *

--- a/src/server/game/Entities/Vehicle/Vehicle.h
+++ b/src/server/game/Entities/Vehicle/Vehicle.h
@@ -60,6 +60,7 @@ class TC_GAME_API Vehicle : public TransportBase
         void RelocatePassengers();
         void RemoveAllPassengers();
         bool IsVehicleInUse() const;
+        bool IsControllableVehicle() const;
 
         void SetLastShootPos(Position const& pos) { _lastShootPos.Relocate(pos); }
         Position const& GetLastShootPos() const { return _lastShootPos; }

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -7369,7 +7369,7 @@ bool Spell::CheckEffectTarget(Unit const* target, uint32 eff, Position const* lo
         case SPELL_AURA_MOD_POSSESS:
         case SPELL_AURA_MOD_CHARM:
         case SPELL_AURA_AOE_CHARM:
-            if (target->GetTypeId() == TYPEID_UNIT && target->IsVehicle())
+            if (target->GetVehicleKit() && target->GetVehicleKit()->IsControllableVehicle())
                 return false;
             if (target->IsMounted())
                 return false;


### PR DESCRIPTION
**Changes proposed**:

- Commit from  Shauren@1fecbc6892b41bfe9d1e474d038c3b1f6e2dd125
- Fixes crash when trying to mind control a non-controllable vehicle.

**Issues addressed**: Fixes #229 

**Tests performed**:  
It builds, but have not tested in-game.
Test in-game by:
1. add item Gnomish Thinking Cap (48945) and equip
2. Use item on Gormok the Impaler (34796)
3. Server should not crash, and should properly check if the target is a controllable vehicle instead of just a vehicle in general.

**Known issues and TODO list**:

- [ ] 
- [ ] 
