### PR TITLE
Core/Maps: add the tolerance to the check for the ground under water

### DIFF
--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -2490,7 +2490,7 @@ inline ZLiquidStatus GridMap::GetLiquidStatus(float x, float y, float z, uint8 R
     float ground_level = getHeight(x, y);
 
     // Check water level and ground level
-    if (liquid_level < ground_level || z < ground_level)
+    if (liquid_level < ground_level || z < ground_level - GROUND_HEIGHT_TOLERANCE)
         return LIQUID_MAP_NO_WATER;
 
     // All ok in water -> store data


### PR DESCRIPTION
**Changes proposed**:

- spells like https://www.wowhead.com/spell=73701/sea-legs was removed if player hit the ground in Vash'jir. 
- The Spell has Interrupt Flags `AURA_INTERRUPT_FLAG_NOT_UNDERWATER` and this was triggered at hitting the ground in Vash'jir
- Whit this change it's works
- 

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)
build and works

**Known issues and TODO list**:

- [ ] 
- [ ] 
