### PR TITLE
Fix handling of ACHIEVEMENT_CRITERIA_COMPLETE_QUEST

### DIFF
--- a/src/server/game/Achievements/AchievementMgr.cpp
+++ b/src/server/game/Achievements/AchievementMgr.cpp
@@ -1341,6 +1341,8 @@ void AchievementMgr<T>::UpdateAchievementCriteria(AchievementCriteriaTypes type,
             SetCriteriaProgress(achievementCriteria, miscValue1, referencePlayer);
             break;
         case ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST:
+            SetCriteriaProgress(achievementCriteria, 1, referencePlayer, PROGRESS_ACCUMULATE);
+            break;
         case ACHIEVEMENT_CRITERIA_TYPE_LEARN_SPELL:
         case ACHIEVEMENT_CRITERIA_TYPE_EXPLORE_AREA:
         case ACHIEVEMENT_CRITERIA_TYPE_VISIT_BARBER_SHOP:
@@ -1572,7 +1574,7 @@ bool AchievementMgr<T>::IsCompletedCriteria(AchievementCriteriaEntry const* achi
         case ACHIEVEMENT_CRITERIA_TYPE_FALL_WITHOUT_DYING:
             return progress->counter >= achievementCriteria->fall_without_dying.fallHeight;
         case ACHIEVEMENT_CRITERIA_TYPE_COMPLETE_QUEST:
-            return progress->counter >= 1;
+            return progress->counter >= achievementCriteria->complete_quest.questCount;
         case ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET:
         case ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2:
             return progress->counter >= achievementCriteria->be_spell_target.spellCount;


### PR DESCRIPTION
**Changes proposed**:

- Fix handling achievement criteria 27 (`ACHIEVEMENT_CRITERIA_COMPLETE_QUEST`) when quantity is more than 1.

**Issues addressed**: Fixes ![](https://i.imgur.com/e6FCag4.png)

**Tests performed**: Nil.

Can be retrofuckported to master.
