### PR TITLE
Core/Datastore: fix structure of ItemExtendedCost hotfix table

### DIFF
--- a/sql/updates/hotfixes/4.3.4/2021_04_15_00_hotfixes.sql
+++ b/sql/updates/hotfixes/4.3.4/2021_04_15_00_hotfixes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `item_extended_cost`
+	ADD COLUMN `RequiredGuildLevel` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `RequirementFlags`;

--- a/src/server/database/Database/Implementation/HotfixDatabase.cpp
+++ b/src/server/database/Database/Implementation/HotfixDatabase.cpp
@@ -48,7 +48,7 @@ void HotfixDatabaseConnection::DoPrepareStatements()
         "RequiredPersonalArenaRating, ItemPurchaseGroup, "
         "RequiredCurrency1, RequiredCurrency2, RequiredCurrency3, RequiredCurrency4, RequiredCurrency5, "
         "RequiredCurrencyCount1, RequiredCurrencyCount2, RequiredCurrencyCount3, RequiredCurrencyCount4, RequiredCurrencyCount5, "
-        "RequiredFactionId, RequiredFactionStanding, RequirementFlags, RequiredAchievement FROM item_extended_cost ORDER BY ID DESC", CONNECTION_SYNCH);
+        "RequiredFactionId, RequiredFactionStanding, RequirementFlags, RequiredGuildLevel, RequiredAchievement FROM item_extended_cost ORDER BY ID DESC", CONNECTION_SYNCH);
 
     // Item-sparse.db2
     PrepareStatement(HOTFIX_SEL_ITEM_SPARSE, "SELECT ID, Quality, Flags1, Flags2, PriceRandomValue, PriceVariance, BuyCount, BuyPrice, SellPrice, InventoryType, "


### PR DESCRIPTION
**Changes proposed**:

- Fix the structure of the hotfix table item_extended_cost to match the DB2. Currently loading this table is silently failing.

**Tests performed**: Built and tested ingame

**Known issues and TODO list**: None