### PR TITLE
Core/Channel: Implement use of CHANNEL_DBC_FLAG_INITIAL

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -4650,6 +4650,9 @@ void Player::UpdateLocalChannels(uint32 newZone)
         if (!channelEntry)
             continue;
 
+        if (!(channelEntry->Flags & CHANNEL_DBC_FLAG_INITIAL))
+            continue;
+
         Channel* usedChannel = nullptr;
         for (Channel* channel : m_channels)
         {


### PR DESCRIPTION
Reduces differences with TC

**Changes proposed**:

- Only attempt to auto-join channels with `CHANNEL_DBC_FLAG_INITIAL`. Stops the server always trying to auto-join players to the WorldDefense channel (client ignores it).
- Reduces difference with TC master

**Tests performed**: Built and tested ingame

**Known issues and TODO list**: None