### PR TITLE
Core/Items: Prevent broken items from applying reforge effects

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13074,7 +13074,7 @@ void Player::AddEnchantmentDuration(Item* item, EnchantmentSlot slot, uint32 dur
 
 void Player::ApplyReforgeEnchantment(Item* item, bool apply)
 {
-    if (!item)
+    if (!item || item->IsBroken())
         return;
 
     ItemReforgeEntry const* reforge = sItemReforgeStore.LookupEntry(item->GetEnchantmentId(REFORGE_ENCHANTMENT_SLOT));

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -684,8 +684,6 @@ void WorldSession::SendListInventory(ObjectGuid vendorGuid)
             item.Price = price;
             item.ItemID = vendorItem->item;
             item.ItemDisplayInfoID = itemTemplate->GetDisplayID();
-            if (vendorItem->ExtendedCost)
-                item.ExtendedCostID = vendorItem->ExtendedCost;
         }
         else if (vendorItem->Type == ITEM_VENDOR_TYPE_CURRENCY)
         {


### PR DESCRIPTION
**Changes proposed**:

- Prevents the possibility of reforged effects being activated on broken items
- Removed a duplicate line in SendListInventory

**Tests performed**: Built and tested ingame

**Known issues and TODO list**: None
