### PR TITLE
Replace Travis-CI shield with CircleCI/AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 4.3.4 
 :------------:
-[![4.3.4 Build Status](https://travis-ci.com/The-Cataclysm-Preservation-Project/TrinityCore.svg?branch=master)](https://travis-ci.com/The-Cataclysm-Preservation-Project/TrinityCore)
+[![CircleCI Status](https://circleci.com/gh/The-Cataclysm-Preservation-Project/TrinityCore.svg?style=shield&branch=master)](https://app.circleci.com/pipelines/github/The-Cataclysm-Preservation-Project/TrinityCore?branch=master)
+[![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/The-Cataclysm-Preservation-Project/TrinityCore?branch=master&svg=true)](https://ci.appveyor.com/project/Ovahlord/trinitycore)
 
 ## Introduction
 


### PR DESCRIPTION
I figured this made some sense, since the last build on Travis is from six months ago. Ultimately not a huge change, but a small QoL thing.

**Changes proposed**:

- Replace Travis-CI shield with CircleCI and AppVeyor

**Issues addressed**: None

**Tests performed**: Tested in preview and browser

**Known issues and TODO list**:
None
