### PR TITLE
DB/Vendor Add missing items to some Hyjal vendors

### DIFF
--- a/sql/updates/world/4.3.4/2021_07_17_00_world.sql
+++ b/sql/updates/world/4.3.4/2021_07_17_00_world.sql
@@ -1,0 +1,49 @@
+--- 43495, Nunaha Grasshoof
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '1', '7005', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '2', '4289', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '3', '2320', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '4', '2321', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '5', '4291', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '6', '8343', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '7', '14341', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '8', '38426', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '9', '2325', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '10', '6260', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '11', '2604', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '12', '2605', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '13', '4340', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '14', '4341', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '15', '6261', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '16', '4342', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '17', '10290', '0', '0', '0', '1', '0', '0');
+
+--- 43550 - Inoho Stronghide
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '1', '7005', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '2', '4289', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '3', '2320', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '4', '2321', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '5', '4291', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '6', '8343', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '7', '14341', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '8', '38426', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '9', '2325', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '10', '6260', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '11', '2604', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '12', '2605', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '13', '4340', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '14', '4341', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '15', '6261', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '16', '4342', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '17', '10290', '0', '0', '0', '1', '0', '0');
+
+--- 43551 - Nenduil Meadowshade
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '1', '58279', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '2', '58260', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '3', '58274', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '4', '58256', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '5', '17034', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '6', '17031', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '7', '17032', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '8', '17020', '0', '0', '0', '1', '0', '0');
+INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '9', '17030', '0', '0', '0', '1', '0', '0');
+

--- a/sql/updates/world/4.3.4/2021_07_17_00_world.sql
+++ b/sql/updates/world/4.3.4/2021_07_17_00_world.sql
@@ -1,49 +1,54 @@
 --- 43495, Nunaha Grasshoof
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '1', '7005', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '2', '4289', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '3', '2320', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '4', '2321', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '5', '4291', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '6', '8343', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '7', '14341', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '8', '38426', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '9', '2325', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '10', '6260', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '11', '2604', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '12', '2605', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '13', '4340', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '14', '4341', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '15', '6261', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '16', '4342', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43495', '17', '10290', '0', '0', '0', '1', '0', '0');
+SET @ENTRY := 43495;
+INSERT INTO npc_vendor(entry, slot, item, maxcount, incrtime, ExtendedCost, type, PlayerConditionID, VerifiedBuild) VALUES
+(@ENTRY, 1, 7005, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 2, 4289, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 3, 2320, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 4, 2321, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 5, 4291, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 6, 8343, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 7, 14341, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 8, 38426, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 9, 2325, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 10, 6260, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 11, 2604, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 12, 2605, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 13, 4340, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 14, 4341, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 15, 6261, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 16, 4342, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 17, 10290, 0, 0, 0, 1, 0, 0);
 
 --- 43550 - Inoho Stronghide
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '1', '7005', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '2', '4289', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '3', '2320', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '4', '2321', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '5', '4291', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '6', '8343', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '7', '14341', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '8', '38426', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '9', '2325', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '10', '6260', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '11', '2604', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '12', '2605', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '13', '4340', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '14', '4341', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '15', '6261', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '16', '4342', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43550', '17', '10290', '0', '0', '0', '1', '0', '0');
+SET @ENTRY := 43550;
+INSERT INTO npc_vendor(entry, slot, item, maxcount, incrtime, ExtendedCost, type, PlayerConditionID, VerifiedBuild) VALUES
+(@ENTRY, 1, 7005, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 2, 4289, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 3, 2320, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 4, 2321, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 5, 4291, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 6, 8343, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 7, 14341, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 8, 38426, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 9, 2325, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 10, 6260, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 11, 2604, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 12, 2605, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 13, 4340, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 14, 4341, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 15, 6261, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 16, 4342, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 17, 10290, 0, 0, 0, 1, 0, 0);
 
 --- 43551 - Nenduil Meadowshade
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '1', '58279', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '2', '58260', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '3', '58274', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '4', '58256', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '5', '17034', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '6', '17031', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '7', '17032', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '8', '17020', '0', '0', '0', '1', '0', '0');
-INSERT INTO `world`.`npc_vendor` (`entry`, `slot`, `item`, `maxcount`, `incrtime`, `ExtendedCost`, `type`, `PlayerConditionID`, `VerifiedBuild`) VALUES ('43551', '9', '17030', '0', '0', '0', '1', '0', '0');
-
+SET @ENTRY := 43551;
+INSERT INTO npc_vendor(entry, slot, item, maxcount, incrtime, ExtendedCost, type, PlayerConditionID, VerifiedBuild) VALUES
+(@ENTRY, 1, 58279, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 2, 58260, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 3, 58274, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 4, 58256, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 5, 17034, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 6, 17031, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 7, 17032, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 8, 17020, 0, 0, 0, 1, 0, 0),
+(@ENTRY, 9, 17030, 0, 0, 0, 1, 0, 0);

--- a/sql/updates/world/4.3.4/2021_07_17_00_world.sql
+++ b/sql/updates/world/4.3.4/2021_07_17_00_world.sql
@@ -1,4 +1,4 @@
---- 43495, Nunaha Grasshoof
+ -- 43495, Nunaha Grasshoof
 SET @ENTRY := 43495;
 INSERT INTO npc_vendor(entry, slot, item, maxcount, incrtime, ExtendedCost, type, PlayerConditionID, VerifiedBuild) VALUES
 (@ENTRY, 1, 7005, 0, 0, 0, 1, 0, 0),
@@ -19,7 +19,7 @@ INSERT INTO npc_vendor(entry, slot, item, maxcount, incrtime, ExtendedCost, type
 (@ENTRY, 16, 4342, 0, 0, 0, 1, 0, 0),
 (@ENTRY, 17, 10290, 0, 0, 0, 1, 0, 0);
 
---- 43550 - Inoho Stronghide
+ -- 43550 - Inoho Stronghide
 SET @ENTRY := 43550;
 INSERT INTO npc_vendor(entry, slot, item, maxcount, incrtime, ExtendedCost, type, PlayerConditionID, VerifiedBuild) VALUES
 (@ENTRY, 1, 7005, 0, 0, 0, 1, 0, 0),
@@ -40,7 +40,7 @@ INSERT INTO npc_vendor(entry, slot, item, maxcount, incrtime, ExtendedCost, type
 (@ENTRY, 16, 4342, 0, 0, 0, 1, 0, 0),
 (@ENTRY, 17, 10290, 0, 0, 0, 1, 0, 0);
 
---- 43551 - Nenduil Meadowshade
+ -- 43551 - Nenduil Meadowshade
 SET @ENTRY := 43551;
 INSERT INTO npc_vendor(entry, slot, item, maxcount, incrtime, ExtendedCost, type, PlayerConditionID, VerifiedBuild) VALUES
 (@ENTRY, 1, 58279, 0, 0, 0, 1, 0, 0),


### PR DESCRIPTION
**Changes proposed**:

- This change adds general/repair shop items to 43495, 43550 and 43551, all in Hyjal.

**Issues addressed**: None

**Tests performed**: Added to database and npc_vendor reloaded on the server. Worked as expected.

**Known issues and TODO list**: None
