### PR TITLE
Core/Spells: Implement SPELL_ATTR10_PROC_COOLDOWN_PER_TARGET

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -205,8 +205,8 @@ class TC_GAME_API Aura
         bool CheckAreaTarget(Unit* target);
         bool CanStackWith(Aura const* existingAura) const;
 
-        bool IsProcOnCooldown(std::chrono::steady_clock::time_point now) const;
-        void AddProcCooldown(std::chrono::steady_clock::time_point cooldownEnd);
+        bool IsProcOnCooldown(std::chrono::steady_clock::time_point now, ObjectGuid procTarget = ObjectGuid::Empty) const;
+        void AddProcCooldown(std::chrono::steady_clock::time_point cooldownEnd, ObjectGuid procTarget = ObjectGuid::Empty);
         void ResetProcCooldown();
         bool IsUsingCharges() const { return m_isUsingCharges; }
         void SetUsingCharges(bool val) { m_isUsingCharges = val; }
@@ -283,6 +283,7 @@ class TC_GAME_API Aura
         ChargeDropEvent* m_dropEvent;
 
         std::chrono::steady_clock::time_point m_procCooldown;
+        std::unordered_map<ObjectGuid, std::chrono::steady_clock::time_point> m_targetProcCooldown;
 
     private:
         Unit::AuraApplicationList m_removedApplications;

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -4872,7 +4872,7 @@ class spell_item_blind_spot : public SpellScript
         if (AuraEffect const* effect = target->GetAuraEffect(spellId, EFFECT_0, target->GetGUID()))
         {
             std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-            effect->GetBase()->AddProcCooldown(now + 30s);
+            effect->GetBase()->AddProcCooldown(now + 30s, GetHitUnit()->GetGUID());
         }
     }
 


### PR DESCRIPTION
**Changes proposed**:

- Implement `SPELL_ATTR10_PROC_COOLDOWN_PER_TARGET`.

**Issues addressed**: *nil*

**Tests performed**: Builds
Can't really test ingame since the only affected spell in Cataclysm is Spellweaving from Madness of Deathwing.

**Known issues and TODO list**: It's a well known fact i make ~~plenty~~ no mistake.