### PR TITLE
Patch authentication modules under linux in the wine ProgramData path

### DIFF
--- a/src/tools/connection_patcher/Program.cpp
+++ b/src/tools/connection_patcher/Program.cpp
@@ -257,8 +257,6 @@ int main(int argc, char** argv)
         std::string renamed_binary_path(binary_path);
 #ifdef _WIN32
         wchar_t* commonAppData(nullptr);
-#endif
-#ifdef _WIN32
         SHGetKnownFolderPath(FOLDERID_ProgramData, 0, nullptr, &commonAppData);
 #endif
 


### PR DESCRIPTION
**Changes proposed**:
- Patch the wine ProgramData specific path on Linux instead of attempting to write to the windows specific path

**Tests performed**:
- It builds
- The authentication modules are put at the correct path
- The client seems to be able to connect with those modules
