### PR TITLE
[Zone/Dun Morogh] Quest #28868 fixed

### DIFF
--- a/sql/updates/world/4.3.4/2021_08_27_00_world.sql
+++ b/sql/updates/world/4.3.4/2021_08_27_00_world.sql
@@ -1,0 +1,1 @@
+UPDATE `creature` SET `ScriptName` = "npc_frostmane_builder" WHERE id=41251;

--- a/src/server/scripts/EasternKingdoms/zone_dun_morogh.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_dun_morogh.cpp
@@ -19,13 +19,77 @@
 #include "MotionMaster.h"
 #include "ScriptedCreature.h"
 
+enum FrostmaneBuilder
+{
+    SPELL_EQUALIZE_VIEWPOINT = 93773,
+    QUEST_FROSTMANE_BUILDER_CREDIT = 50606
+};
+
 enum FrozenMountaineer
 {
-    DATA_SET_ICE_BROKEN      = 1,
-    EVENT_RUN_AWAY           = 1,
-    SAY_MONSTEREMOTE         = 0,
+    DATA_SET_ICE_BROKEN = 1,
+    EVENT_RUN_AWAY = 1,
+    SAY_MONSTEREMOTE = 0,
     SPELL_SUMMON_FROZEN_TOMB = 77906,
-    SPELL_FREEZE_ANIM        = 77910
+    SPELL_FREEZE_ANIM = 77910
+};
+
+/*######
+# npc_frostmane_builder
+######*/
+
+class npc_frostmane_builder : public CreatureScript
+{
+public:
+    npc_frostmane_builder() : CreatureScript("npc_frostmane_builder") {}
+    struct npc_frostmane_builderAI : public ScriptedAI
+    {
+        npc_frostmane_builderAI(Creature* creature) : ScriptedAI(creature), _hitBySpell(false)
+        {
+            Initialize();
+        }
+
+        void Initialize()
+        {
+            _hitBySpell = false;
+        }
+
+        void Reset() override
+        {
+            Initialize();
+        }
+
+
+        void SpellHit(Unit* caster, SpellInfo const* spell) override
+        {
+            if (!_hitBySpell)
+                _hitBySpell = true;
+
+            if (spell->Id == SPELL_EQUALIZE_VIEWPOINT)
+            {
+                if (Player* player = caster->ToPlayer())
+                    player->KilledMonsterCredit(QUEST_FROSTMANE_BUILDER_CREDIT);
+            }
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            if (!_hitBySpell)
+                return;
+
+            _events.Update(diff);
+        }
+
+    private:
+        EventMap _events;
+        ObjectGuid _playerGUID;
+        bool _hitBySpell;
+    };
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_frostmane_builderAI(creature);
+    }
 };
 
 /*######
@@ -86,4 +150,5 @@ public:
 void AddSC_dun_morogh()
 {
     new npc_frozen_mountaineer();
+    new npc_frostmane_builder();
 }


### PR DESCRIPTION
**Changes proposed**:
Fixed quest "The View From Down Here" (#28868) which doesn't scale up credit when the quest target creatures are shrunk by the "Viewpoint Equalizer" quest item.

Not sure if this was ever fixed in the master TrinityCore repo (https://github.com/TrinityCore/TrinityCore/issues/16380)

**Issues addressed**: Fixes quest #28868 which was impossible to complete.

**Tests performed**: Built statically, tested in-game.

**Known issues and TODO list**:
The Frostmane Builders should play ANIM_EMOTE_WORK just like Blizzard WoW.
Maybe
```
   if (!me->IsInCombat() && !me->isMoving())
                me->HandleEmoteCommand(ANIM_EMOTE_WORK);
```
could do it? I didn't have time to test it.

I am not sure but I think this quest does not become available until you complete "The Ultrasafe Personnel Launcher" (25839) (which, unsurprisingly, cannot be completed aswell)
