### PR TITLE
Core/Spells: removing IsFriendlyTo from EffectPickPocket

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2103,8 +2103,8 @@ void Spell::EffectPickPocket(SpellEffIndex /*effIndex*/)
     if (m_caster->GetTypeId() != TYPEID_PLAYER)
         return;
 
-    // victim must be creature and attackable
-    if (!unitTarget || unitTarget->GetTypeId() != TYPEID_UNIT || m_caster->IsFriendlyTo(unitTarget))
+    // victim must be creature
+    if (!unitTarget || unitTarget->GetTypeId() != TYPEID_UNIT)
         return;
 
     // victim have to be alive and humanoid or undead


### PR DESCRIPTION
* it's unneeded because it's already handled by the target type.
* adding support for cases where spells from questlines require the player to pick loot a certain creature that is friendly to the caster, so the loot window wouldn't show up.

**Changes proposed**:
- removing IsFriendlyTo from EffectPickPocket since it's unneeded because it's already handled by the target type.

**Issues addressed**: Fixes Collect Forsaken Insignia (84379).

**Tests performed**: It builds and is tested in-game.