### PR TITLE
DB/Locale: altering quest_greeting_locale so that locale column is inserted as a primary key

### DIFF
--- a/sql/updates/world/4.3.4/2021_10_31_00_world.sql
+++ b/sql/updates/world/4.3.4/2021_10_31_00_world.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `quest_greeting_locale`
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`ID`, `Type`, `locale`) USING BTREE;


### PR DESCRIPTION
**Changes proposed**: Alter column locale from quest_greeting_locale so that the different locales can be used individually for each ID and Type.

**Issues addressed**: Fixes quest_greeting_locale not allowing you to add the same locale for two or more different IDs or Types.

**Tests performed**: It builds and is tested in-game.

**Known issues and TODO list**: Nothing.