### PR TITLE
Core/Instance: Send combat res limit to client at encounter start

### DIFF
--- a/src/server/game/Instances/InstanceScript.cpp
+++ b/src/server/game/Instances/InstanceScript.cpp
@@ -376,7 +376,7 @@ bool InstanceScript::SetBossState(uint32 id, EncounterState state)
                 {
                     case IN_PROGRESS:
                         InitializeCombatResurrections();
-                        SendEncounterUnit(ENCOUNTER_FRAME_SET_COMBAT_RES_LIMIT);
+                        SendEncounterUnit(ENCOUNTER_FRAME_SET_COMBAT_RES_LIMIT, nullptr, GetCombatResurrectionCharges());
                         break;
                     case FAIL:
                     case DONE:

--- a/src/server/scripts/Kalimdor/HallsOfOrigination/boss_isiset.cpp
+++ b/src/server/scripts/Kalimdor/HallsOfOrigination/boss_isiset.cpp
@@ -152,7 +152,6 @@ public:
             if (IsHeroic())
                 DoCastSelf(SPELL_CALL_OF_SKY);
             RescheduleEvents();
-            instance->SendEncounterUnit(ENCOUNTER_FRAME_SET_COMBAT_RES_LIMIT, 0);
         }
 
         void DamageTaken(Unit* /*attacker*/, uint32 &damage) override
@@ -191,7 +190,6 @@ public:
 
         void JustDied(Unit* /*killer*/) override
         {
-            //instance->SendEncounterUnit(ENCOUNTER_FRAME_SET_COMBAT_RES_LIMIT, ?me?, 1); //from sniff, not sure what it does
             instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me, 0);
             _JustDied();
             Talk(SAY_DEATH);


### PR DESCRIPTION
**Changes proposed**:

- Add actual combat resurrection limit to `ENCOUNTER_FRAME_SET_COMBAT_RES_LIMIT` packet being sent to client at the start of a raid encounter

**Tests performed**: Built and tested ingame
