### PR TITLE
Scripts/TSC: Fix Force Grip effect not starting

### DIFF
--- a/src/server/scripts/Maelstrom/Stonecore/boss_high_priestess_azil.cpp
+++ b/src/server/scripts/Maelstrom/Stonecore/boss_high_priestess_azil.cpp
@@ -198,9 +198,9 @@ class boss_high_priestess_azil : public CreatureScript
                 me->ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_INTERRUPT_CAST, !apply);
             }
 
-            void OnSpellCastFinished(SpellInfo const* spell, SpellFinishReason /*reason*/) override
+            void OnSpellCastFinished(SpellInfo const* spell, SpellFinishReason reason) override
             {
-                if (spell->Id == SPELL_FORCE_GRIP)
+                if (spell->Id == SPELL_FORCE_GRIP && reason != SPELL_FINISHED_SUCCESSFUL_CAST)
                 {
                     MakeInterruptable(false);
                     SetVehicleId(VEHICLE_ID_DEFAULT);


### PR DESCRIPTION
**Changes proposed**:

Fix Azil's Force Grip ability not doing anything (and sometimes crashing the core), because the vehicle was being removed at the start of the channel.

**Tests performed**: Built and tested ingame

**Known issues and TODO list**:

There's still another problem with the ability. When the channel ends, the player is left stuck up in the air unable to move. I haven't been able to come up with a proper fix for that yet, my knowledge of the vehicle system is limited.
