### PR TITLE
Fix chase movement

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ChaseMovementGenerator.cpp
@@ -75,6 +75,28 @@ inline float GetChaseRange(Unit const* owner, Unit const* target)
     return hitboxSum;
 }
 
+static bool isNextStepValid(PathGenerator path, Unit const* owner) {
+    
+    if (!owner->CanFly()) {
+
+        float prevStepZ = 0;
+        for (auto& step : path.GetPath()) {
+
+            if (prevStepZ == 0) {
+                prevStepZ = step.z;
+            }
+
+            if (step.z - prevStepZ > 5.0f) {
+                return false;
+            }
+            else {
+                prevStepZ = step.z;
+            }
+        }
+    }
+    return true;
+}
+
 ChaseMovementGenerator::ChaseMovementGenerator(Unit* target, float range, Optional<ChaseAngle> angle) : AbstractPursuer(PursuingType::Chase, ASSERT_NOTNULL(target)), _range(range), _angle(angle) { }
 ChaseMovementGenerator::~ChaseMovementGenerator() = default;
 
@@ -241,7 +263,7 @@ void ChaseMovementGenerator::LaunchMovement(Unit* owner, float chaseRange, bool 
 
     PathGenerator path(owner);
     bool success = path.CalculatePath(dest.GetPositionX(), dest.GetPositionY(), dest.GetPositionZ(), owner->CanFly());
-    if (!success || (path.GetPathType() & (PATHFIND_NOPATH /*| PATHFIND_INCOMPLETE*/)))
+    if (!success || (path.GetPathType() & (PATHFIND_NOPATH /*| PATHFIND_INCOMPLETE*/)) || !isNextStepValid(path, owner))
     {
         if (creature)
             creature->SetCannotReachTarget(true);


### PR DESCRIPTION
**Changes proposed**:

- Added method for checking if next step of chasing unit is valid

**Issues addressed**: 

- Fixes #345 

**Tests performed**: 

- Builds
- Tested in game, everything seems to work exactly as inteded i.e. chasing targets will no longer walk in air nor clip through terrain and objects. Chasing targets can still reach its target that are on higher ground if there is a valid path leading to it.

**Note**:

- I went with 5 yards difference as I think that sounds reasonable, but it can be up for discussion whether this should be increased or decreased.
