### PR TITLE
Update ConfusedMovementGenerator.cpp

### DIFF
--- a/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/ConfusedMovementGenerator.cpp
@@ -75,6 +75,7 @@ bool ConfusedMovementGenerator<T>::DoUpdate(T* owner, uint32 diff)
         float distance = 4.0f * frand(0.0f, 1.0f) - 2.0f;
         float angle = frand(0.0f, 1.0f) * float(M_PI) * 2.0f;
         owner->MovePositionToFirstCollision(destination, distance, angle);
+        owner->SetOrientation(owner->GetAngle(destination));
 
         if (!_path)
             _path = new PathGenerator(owner);
@@ -92,6 +93,7 @@ bool ConfusedMovementGenerator<T>::DoUpdate(T* owner, uint32 diff)
         Movement::MoveSplineInit init(owner);
         init.MovebyPath(_path->GetPath());
         init.SetWalk(true);
+        init.SetFacing(owner->GetAngle(destination));
         int32 traveltime = init.Launch();
         _timer.Reset(traveltime + urand(800, 1500));
     }


### PR DESCRIPTION
**Changes proposed**:

- Set the direction of orientation and facing of confused targets, so it matches the direction their character model is facing.

**Issues addressed**:

- Without this fix, a confused unit will wander in random directions as intended, however their actual orientation does not change, which makes it difficult to use abilities such as Rogues Backstab that requires one to be behind the target. 

**Tests performed**: 

- Builds
- Tested in game, works as intended.
