### PR TITLE
Fix Druid Pounce Bleed affected by DR

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2577,7 +2577,7 @@ void SpellInfo::_LoadSpellDiminishInfo()
             }
             case SPELLFAMILY_DRUID:
             {
-                // Pounce
+                // Pounce - there are two spells which share the same family: the stun effect and the bleed spell. We don't want the bleed to be affected by DR
                 if ((SpellFamilyFlags[0] & 0x20000) && Id != 9007)
                     return DIMINISHING_OPENING_STUN;
                 // Cyclone

--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -2578,7 +2578,7 @@ void SpellInfo::_LoadSpellDiminishInfo()
             case SPELLFAMILY_DRUID:
             {
                 // Pounce
-                if (SpellFamilyFlags[0] & 0x20000)
+                if ((SpellFamilyFlags[0] & 0x20000) && Id != 9007)
                     return DIMINISHING_OPENING_STUN;
                 // Cyclone
                 else if (SpellFamilyFlags[1] & 0x20)


### PR DESCRIPTION
**Changes proposed**:

- Fix Pounce Bleed being affected by diminishing returns

**Issues addressed**: 

- Fixes #76 

**Tests performed**: 

- Builds
- Tested in-game, works as intended. Pounce Stun is still affected by DR as it should be.

**Known issues and TODO list**:

- None
