### PR TITLE
Fix Shaman Totems and Elementals

### DIFF
--- a/src/server/game/Entities/Creature/TemporarySummon.cpp
+++ b/src/server/game/Entities/Creature/TemporarySummon.cpp
@@ -215,6 +215,7 @@ void TempSummon::InitStats(uint32 duration)
         }
 
         if (owner->IsTotem())
+        {
             owner->m_Controlled.insert(this);
 
             // Store the totem elementals in totem owner's controlled list as well to trigger aggro mechanics
@@ -229,6 +230,7 @@ void TempSummon::InitStats(uint32 duration)
                     SetByteValue(UNIT_FIELD_BYTES_2, UNIT_BYTES_2_OFFSET_PVP_FLAG, totemOwner->GetByteValue(UNIT_FIELD_BYTES_2, UNIT_BYTES_2_OFFSET_PVP_FLAG));
                 }
             }
+        }
     }
 
     // If property has a faction defined, use it.

--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -66,6 +66,11 @@ void Totem::InitStats(uint32 duration)
 
         // set display id depending on caster's race
         SetDisplayId(GetOwner()->GetModelForTotem(PlayerTotemType(m_Properties->ID)));
+
+        SetOwnerGUID(GetOwner()->GetGUID());
+        m_ControlledByPlayer = true;
+        SetUInt32Value(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);
+        SetByteValue(UNIT_FIELD_BYTES_2, UNIT_BYTES_2_OFFSET_PVP_FLAG, GetOwner()->GetByteValue(UNIT_FIELD_BYTES_2, UNIT_BYTES_2_OFFSET_PVP_FLAG));
     }
 
     Minion::InitStats(duration);


### PR DESCRIPTION
**Changes proposed**:

- Totems and Elementals will now properly engage in both PvE and PvP combat.
- Totems and Elementals are now properly affected by sanctuary and FFA areas as well as dueling state.
- Elementals will now aggro when its owner is attacked.

**Issues addressed**: 

- Fixes #87 
- Fixes #213

**Tests performed**: 

- Builds
- Tested in duels both same faction and cross faction, contested area, sanctuary area (Dalaran Sewers), FFA PvP area (Gurubashi Arena). Works as intended.

**Known issues and TODO list**:

- None from what I can tell.