### PR TITLE
Fix Rogue spell Redirect

### DIFF
--- a/sql/updates/world/4.3.4/2022_10_16_00_world.sql
+++ b/sql/updates/world/4.3.4/2022_10_16_00_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `ScriptName`= 'spell_rog_redirect';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (73981, 'spell_rog_redirect');

--- a/src/server/scripts/Spells/spell_rogue.cpp
+++ b/src/server/scripts/Spells/spell_rogue.cpp
@@ -1570,6 +1570,33 @@ class spell_rog_pickpocket : public SpellScript
     }
 };
 
+// 73981 - Redirect
+class spell_rog_redirect : public SpellScript
+{
+    SpellCastResult CheckCast()
+    {
+        Unit* caster = GetCaster();
+        Player* player = caster->ToPlayer();
+        uint8 const comboPoints = player->GetComboPoints();
+        if (!comboPoints)
+            return SPELL_FAILED_NO_COMBO_POINTS;
+
+        Unit* target = GetExplTargetUnit();
+        if (target->GetGUID() == player->GetComboTarget())
+            return SPELL_FAILED_BAD_TARGETS;
+
+        player->ClearComboPoints();
+        player->AddComboPoints(target, comboPoints);
+
+        return SPELL_CAST_OK;
+    }
+
+    void Register() override
+    {
+        OnCheckCast.Register(&spell_rog_redirect::CheckCast);
+    }
+};
+
 void AddSC_rogue_spell_scripts()
 {
     RegisterSpellScript(spell_rog_bandits_guile);
@@ -1607,4 +1634,5 @@ void AddSC_rogue_spell_scripts()
     RegisterSpellScript(spell_rog_tricks_of_the_trade_proc);
     RegisterSpellScript(spell_rog_honor_among_thieves);
     RegisterSpellScript(spell_rog_vanish);
+    RegisterSpellScript(spell_rog_redirect);
 }


### PR DESCRIPTION
**Changes proposed**:

- Can no longer be used without any existing combo points.
- Can no longer be used on target with combo points already.
- Will now properly transfer combo points to a new target.
- Bandit's Guile + Insights will now be transfered along with combo points as intended.

**Issues addressed**: 
- Fixes #207 

**Tests performed**: 
- Builds.
- Works as intended ingame.

**Known issues and TODO list**:

~TODO: Fix transfering bandits guile. This requires some rework of AuraScript ```spell_rog_bandits_guile``` as this will currently always clear insight buffs when hitting a new target.~
