### PR TITLE
Core/Movement: follower will check target's vehicle for follow motion

### DIFF
--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -55,7 +55,20 @@ inline UnitMoveType SelectSpeedType(uint32 moveFlags)
 
 inline bool IsTargetMoving(Unit const* target)
 {
-    return target->HasUnitMovementFlag(MOVEMENTFLAG_FORWARD | MOVEMENTFLAG_BACKWARD | MOVEMENTFLAG_STRAFE_LEFT | MOVEMENTFLAG_STRAFE_RIGHT) || !target->movespline->Finalized();
+    if (target->HasUnitMovementFlag(MOVEMENTFLAG_FORWARD | MOVEMENTFLAG_BACKWARD | MOVEMENTFLAG_STRAFE_LEFT | MOVEMENTFLAG_STRAFE_RIGHT) || !target->movespline->Finalized())
+    {
+        return true;
+    }
+
+    if (Unit* targetVehicle = target->GetVehicleBase())
+    {
+        if (targetVehicle->HasUnitMovementFlag(MOVEMENTFLAG_FORWARD | MOVEMENTFLAG_BACKWARD | MOVEMENTFLAG_STRAFE_LEFT | MOVEMENTFLAG_STRAFE_RIGHT) || !targetVehicle->movespline->Finalized())
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 inline float GetVelocity(Unit* owner, Unit* target, bool catchUp)

--- a/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/FollowMovementGenerator.cpp
@@ -60,7 +60,7 @@ inline bool IsTargetMoving(Unit const* target)
         return true;
     }
 
-    if (Unit* targetVehicle = target->GetVehicleBase())
+    if (Unit const* targetVehicle = target->GetVehicleBase())
     {
         if (targetVehicle->HasUnitMovementFlag(MOVEMENTFLAG_FORWARD | MOVEMENTFLAG_BACKWARD | MOVEMENTFLAG_STRAFE_LEFT | MOVEMENTFLAG_STRAFE_RIGHT) || !targetVehicle->movespline->Finalized())
         {


### PR DESCRIPTION
In this commit i added basic checks which will check target's current vehicle movement flags to determine if it moved.
By default if if player is on vehicle, follow units will not follow player
I honestly unsure if these changes are acceptable by current standarts.

**Changes proposed**:

- Made changes in IsTargetMoving function which will perform follow target vehicle checks to allow follow motion to continue

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)
- Build (windows 11 x64 / Fedora 38 x64)
- Mainly tested on quest https://www.wowhead.com/quest=14416/the-hungry-ettin

**Known issues and TODO list**:
- [ ] 
- [ ] 
