### PR TITLE
Core/Spells: if for TARGET_UNIT_MASTER owner aquire fails, try to retrieve owner by using TempSummon

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1666,8 +1666,17 @@ void Spell::SelectImplicitCasterObjectTargets(SpellEffIndex effIndex, SpellImpli
             checkIfValid = false;
             break;
         case TARGET_UNIT_MASTER:
+        {
             target = m_caster->GetCharmerOrOwner();
+            if (target == nullptr && m_caster->IsCreature())
+            {
+                if (TempSummon const* meTempSummon = m_caster->ToCreature()->ToTempSummon())
+                {
+                    target = meTempSummon->GetSummoner();
+                }
+            }
             break;
+        }
         case TARGET_UNIT_PET:
             if (Unit* unitCaster = m_caster->ToUnit())
                 target = unitCaster->GetGuardianPet();

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1670,9 +1670,9 @@ void Spell::SelectImplicitCasterObjectTargets(SpellEffIndex effIndex, SpellImpli
             target = m_caster->GetCharmerOrOwner();
             if (target == nullptr && m_caster->IsCreature())
             {
-                if (TempSummon const* meTempSummon = m_caster->ToCreature()->ToTempSummon())
+                if (TempSummon const* casterTempSummon = m_caster->ToCreature()->ToTempSummon())
                 {
-                    target = meTempSummon->GetSummoner();
+                    target = casterTempSummon->GetSummoner();
                 }
             }
             break;


### PR DESCRIPTION
**Changes proposed**:

This PR allows to gather owner for TARGET_UNIT_MASTER by using TempSummon if by some case function "GetCharmerOrOwner()" fails to retrieve owner

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

- Build on WIndows 11 64bit (MSVC) & Fedora 38 64bit (GCC)
- Mainly tested with https://www.wowhead.com/quest=14416/the-hungry-ettin, where horses (temp summons) casts `68917` spell for quest credit (unpublished quest script)

**Known issues and TODO list**:

- [ ] 
- [ ] 
