### PR TITLE
Core/Movement: corrected code mistake in WaypointMovementGenerator.cpp

### DIFF
--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -28,12 +28,12 @@
 #include "WaypointManager.h"
 
 WaypointMovementGenerator<Creature>::WaypointMovementGenerator(uint32 pathId, bool repeating) : _lastSplineId(0), _pathId(pathId), _waypointDelay(0),
-    _waypointReached(false), _recalculateSpeed(false), _repeating(repeating), _loadedFromDB(true), _stalled(false), _hasBeenStalled(false), _done(false)
+    _waypointReached(true), _recalculateSpeed(false), _repeating(repeating), _loadedFromDB(true), _stalled(false), _hasBeenStalled(false), _done(false)
 {
 }
 
 WaypointMovementGenerator<Creature>::WaypointMovementGenerator(WaypointPath& path, bool repeating) : _lastSplineId(0), _pathId(0), _waypointDelay(0),
-    _waypointReached(false), _recalculateSpeed(false), _repeating(repeating), _loadedFromDB(false), _stalled(false), _hasBeenStalled(false), _done(false)
+    _waypointReached(true), _recalculateSpeed(false), _repeating(repeating), _loadedFromDB(false), _stalled(false), _hasBeenStalled(false), _done(false)
 {
     _path = &path;
 }


### PR DESCRIPTION
**Changes proposed**:

- This corrects mistake made in https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/pull/423/commits/8563d24a5414852c949d852d7d9a92480a0a8683
- Fixes SAI and sript events

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc)

- Tested mainly with RAZ in blackrock caverns and Fear No Evil quest (human start zone)

**Known issues and TODO list**:

- None
