### PR TITLE
Add OpenSSL legacy provider loading in main.cpp for RC4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 4.3.4 (master) |
 :------------: |
-[![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/The-Cataclysm-Preservation-Project/TrinityCore?branch=master&svg=true)](https://ci.appveyor.com/project/Ovahlord/trinitycore) |
-[![master GCC Build status](https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/actions/workflows/gcc-build.yml/badge.svg?branch=master&event=push)](https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/actions?query=workflow%3AGCC+branch%3Amaster+event%3Apush) |
-[![master clang Build status](https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/actions/workflows/clang-build.yml/badge.svg?branch=master&event=push)](https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/actions?query=workflow%3ACLANG+branch%3Amaster+event%3Apush) |
+[![Build status](https://ci.appveyor.com/api/projects/status/u7b5qi208wulxd3q/branch/master?svg=true)](https://ci.appveyor.com/project/rodrigoangeloni/trinitycorecata/branch/master) |
+[![master GCC Build status](https://github.com/rodrigoangeloni/TrinityCoreCata/actions/workflows/gcc-build.yml/badge.svg?branch=master&event=push)](https://github.com/rodrigoangeloni/TrinityCoreCata/actions?query=workflow%3AGCC+branch%3Amaster+event%3Apush) |
+[![master clang Build status](https://github.com/rodrigoangeloni/TrinityCoreCata/actions/workflows/clang-build.yml/badge.svg?branch=master&event=push)](https://github.com/rodrigoangeloni/TrinityCoreCata/actions?query=workflow%3ACLANG+branch%3Amaster+event%3Apush) |
 
 ## Introduction
 
@@ -29,8 +29,8 @@ website at [TrinityCore.org](https://www.trinitycore.org).
 ## Install
 
 Detailed installation guides are available in the [wiki](https://www.trinitycore.info/display/tc/Installation+Guide) for
-Windows, Linux and Mac OSX.  
-You can get database from  
+Windows, Linux and Mac OSX.
+You can get database from
 https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/releases
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,17 @@ clone_depth: 1
 init:
 - ps: ''
 environment:
-  BOOST_ROOT: C:\Libraries\boost_1_85_0
+  BOOST_ROOT: C:\local\boost_1_78_0
   MYSQL_ROOT_DIR: C:\Program Files\MySQL\MySQL Server 8.0
   OPENSSL_ROOT_DIR: C:\OpenSSL-v32-Win64
+install:
+- ps: |
+    Write-Host "Descargando Boost 1.78.0..." -ForegroundColor Cyan
+    $boostZip = "$($env:temp)\boost_1_78_0.zip"
+    (New-Object Net.WebClient).DownloadFile('https://archives.boost.io/release/1.78.0/source/boost_1_78_0.zip', $boostZip)
+    Write-Host "Descomprimiendo Boost..." -ForegroundColor Cyan
+    7z x $boostZip -o"C:\local" | Out-Null
+    Write-Host "Boost instalado en C:\local\boost_1_78_0" -ForegroundColor Cyan
 build_script:
 - cmd: >-
     git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,29 +28,29 @@ install:
 
 build_script:
 - cmd: |
-  git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
+    git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
 
-  md build && cd build
+    md build && cd build
 
-  cmake -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True -DCMAKE_CXX_FLAGS=" /DWIN32 /D_WINDOWS /W3 /GR /EHsc /WX" -DCMAKE_C_FLAGS="/DWIN32 /D_WINDOWS /W3 /WX" -DCMAKE_PREFIX_PATH=%BOOST_ROOT% ..
+    cmake -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True -DCMAKE_CXX_FLAGS=" /DWIN32 /D_WINDOWS /W3 /GR /EHsc /WX" -DCMAKE_C_FLAGS="/DWIN32 /D_WINDOWS /W3 /WX" -DCMAKE_PREFIX_PATH=%BOOST_ROOT% ..
 
-  "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity=minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
+    "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity=minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
 
-  cd bin\RelWithDebInfo\
+    cd bin\RelWithDebInfo\
 
-  copy "%MYSQL_ROOT_DIR%\lib\libmysql.dll" libmysql.dll
+    copy "%MYSQL_ROOT_DIR%\lib\libmysql.dll" libmysql.dll
 
-  copy "%OPENSSL_ROOT_DIR%\libssl-3-x64.dll" libssl-3-x64.dll
+    copy "%OPENSSL_ROOT_DIR%\libssl-3-x64.dll" libssl-3-x64.dll
 
-  copy "%OPENSSL_ROOT_DIR%\libcrypto-3-x64.dll" libcrypto-3-x64.dll
+    copy "%OPENSSL_ROOT_DIR%\libcrypto-3-x64.dll" libcrypto-3-x64.dll
 
-  cd ..
+    cd ..
 
-  7z a TrinityCoreWin64VS2022.zip .\RelWithDebInfo\*
+    7z a TrinityCoreWin64VS2022.zip .\RelWithDebInfo\*
 
-  del /F /Q /S "RelWithDebInfo\*.pdb" > NUL
+    del /F /Q /S "RelWithDebInfo\*.pdb" > NUL
 
-  7z a TrinityCoreWin64VS2022NoSymbols.zip .\RelWithDebInfo\*
+    7z a TrinityCoreWin64VS2022NoSymbols.zip .\RelWithDebInfo\*
 
 test: off
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,14 +27,14 @@ install:
     Write-Host "MySQL Server 8.0 installed" -ForegroundColor Cyan
 
 build_script:
-cmd: >-
+- cmd: |
   git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
 
   md build && cd build
 
   cmake -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True -DCMAKE_CXX_FLAGS=" /DWIN32 /D_WINDOWS /W3 /GR /EHsc /WX" -DCMAKE_C_FLAGS="/DWIN32 /D_WINDOWS /W3 /WX" -DCMAKE_PREFIX_PATH=%BOOST_ROOT% ..
 
-  "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
+  "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity=minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
 
   cd bin\RelWithDebInfo\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,16 +7,15 @@ environment:
   BOOST_ROOT: C:\Libraries\boost_1_85_0
   MYSQL_ROOT_DIR: C:\Program Files\MySQL\MySQL Server 8.0
   OPENSSL_ROOT_DIR: C:\OpenSSL-v32-Win64
-
 build_script:
-- cmd: |
+- cmd: >-
     git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
 
     cmake -S . -B .\build -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=dynamic -DWITH_WARNINGS_AS_ERRORS=ON -DTOOLS=ON
 
     cd build
 
-    "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity=minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
+    "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
 
     cd bin\RelWithDebInfo\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,15 +4,15 @@ clone_depth: 1
 init:
 - ps: ''
 environment:
-  BOOST_ROOT: C:\Libraries\boost_1_78_0
+  BOOST_ROOT: C:\Libraries\boost_1_85_0
   MYSQL_ROOT_DIR: C:\Program Files\MySQL\MySQL Server 8.0
-  OPENSSL_ROOT_DIR: C:\OpenSSL-v30-Win64
+  OPENSSL_ROOT_DIR: C:\OpenSSL-v32-Win64
 
 build_script:
 - cmd: |
     git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
 
-    cmake -S . -B .\build -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True
+    cmake -S . -B .\build -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=dynamic -DWITH_WARNINGS_AS_ERRORS=ON -DTOOLS=ON
 
     cd build
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_depth: 1
 init:
 - ps: ''
 environment:
-  BOOST_ROOT: C:\Libraries\boost_1_78_0
+  BOOST_ROOT: C:\Libraries\boost_1_85_0
   MYSQL_ROOT_DIR: C:\Program Files\MySQL\MySQL Server 8.0
   OPENSSL_ROOT_DIR: C:\OpenSSL-v32-Win64
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,23 +8,23 @@ environment:
   MYSQL_ROOT_DIR: C:\mysql-8.0.43-winx64
   OPENSSL_ROOT_DIR: C:\OpenSSL-v30-Win64
 install:
-ps: >-
-  # Instalar Boost 1.78.0
-  $boostZip = "$($env:temp)\boost_1_78_0.zip"
-  Write-Host "Descargando Boost 1.78.0..." -ForegroundColor Cyan
-  (New-Object Net.WebClient).DownloadFile('https://archives.boost.io/release/1.78.0/source/boost_1_78_0.zip', $boostZip)
-  Write-Host "Descomprimiendo Boost..." -ForegroundColor Cyan
-  7z x $boostZip -o"C:\local" | Out-Null
-  Write-Host "Boost instalado en C:\local\boost_1_78_0" -ForegroundColor Cyan
+- ps: |
+    # Instalar Boost 1.78.0
+    $boostZip = "$($env:temp)\boost_1_78_0.zip"
+    Write-Host "Descargando Boost 1.78.0..." -ForegroundColor Cyan
+    (New-Object Net.WebClient).DownloadFile('https://archives.boost.io/release/1.78.0/source/boost_1_78_0.zip', $boostZip)
+    Write-Host "Descomprimiendo Boost..." -ForegroundColor Cyan
+    7z x $boostZip -o"C:\local" | Out-Null
+    Write-Host "Boost instalado en C:\local\boost_1_78_0" -ForegroundColor Cyan
 
-  # Instalar MySQL Server 8.0
-  Write-Host "Installing MySQL Server 8.0" -ForegroundColor Cyan
-  Write-Host "Downloading MySQL..."
-  $zipPath = "$($env:temp)\mysql-8.0.43-winx64.zip"
-  (New-Object Net.WebClient).DownloadFile('https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.43-winx64.zip', $zipPath)
-  Write-Host "Unpacking..."
-  7z x $zipPath -o"C:\" | Out-Null
-  Write-Host "MySQL Server 8.0 installed" -ForegroundColor Cyan
+    # Instalar MySQL Server 8.0
+    Write-Host "Installing MySQL Server 8.0" -ForegroundColor Cyan
+    Write-Host "Downloading MySQL..."
+    $zipPath = "$($env:temp)\mysql-8.0.43-winx64.zip"
+    (New-Object Net.WebClient).DownloadFile('https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.43-winx64.zip', $zipPath)
+    Write-Host "Unpacking..."
+    7z x $zipPath -o"C:\" | Out-Null
+    Write-Host "MySQL Server 8.0 installed" -ForegroundColor Cyan
 
 build_script:
 cmd: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,53 +4,34 @@ clone_depth: 1
 init:
 - ps: ''
 environment:
-  BOOST_ROOT: C:\local\boost_1_78_0
-  MYSQL_ROOT_DIR: C:\mysql-8.0.43-winx64
+  BOOST_ROOT: C:\Libraries\boost_1_78_0
+  MYSQL_ROOT_DIR: C:\Program Files\MySQL\MySQL Server 8.0
   OPENSSL_ROOT_DIR: C:\OpenSSL-v30-Win64
-install:
-- ps: |
-    # Instalar Boost 1.78.0
-    $boostZip = "$($env:temp)\boost_1_78_0.zip"
-    Write-Host "Descargando Boost 1.78.0..." -ForegroundColor Cyan
-    (New-Object Net.WebClient).DownloadFile('https://archives.boost.io/release/1.78.0/source/boost_1_78_0.zip', $boostZip)
-    Write-Host "Descomprimiendo Boost..." -ForegroundColor Cyan
-    7z x $boostZip -o"C:\local" | Out-Null
-    Write-Host "Boost instalado en C:\local\boost_1_78_0" -ForegroundColor Cyan
 
-    # Instalar MySQL Server 8.0
-    Write-Host "Installing MySQL Server 8.0" -ForegroundColor Cyan
-    Write-Host "Downloading MySQL..."
-    $zipPath = "$($env:temp)\mysql-8.0.43-winx64.zip"
-    (New-Object Net.WebClient).DownloadFile('https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.43-winx64.zip', $zipPath)
-    Write-Host "Unpacking..."
-    7z x $zipPath -o"C:\" | Out-Null
-    Write-Host "MySQL Server 8.0 installed" -ForegroundColor Cyan
-
-build_script:
 - cmd: |
-    git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
+  git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
 
-    md build && cd build
+  cmake -S . -B .\build -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True
 
-    cmake -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True -DCMAKE_CXX_FLAGS=" /DWIN32 /D_WINDOWS /W3 /GR /EHsc /WX" -DCMAKE_C_FLAGS="/DWIN32 /D_WINDOWS /W3 /WX" -DCMAKE_PREFIX_PATH=%BOOST_ROOT% ..
+  cd build
 
-    "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity=minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
+  "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity=minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
 
-    cd bin\RelWithDebInfo\
+  cd bin\RelWithDebInfo\
 
-    copy "%MYSQL_ROOT_DIR%\lib\libmysql.dll" libmysql.dll
+  copy "%MYSQL_ROOT_DIR%\lib\libmysql.dll" libmysql.dll
 
-    copy "%OPENSSL_ROOT_DIR%\libssl-3-x64.dll" libssl-3-x64.dll
+  copy "%OPENSSL_ROOT_DIR%\libssl-3-x64.dll" libssl-3-x64.dll
 
-    copy "%OPENSSL_ROOT_DIR%\libcrypto-3-x64.dll" libcrypto-3-x64.dll
+  copy "%OPENSSL_ROOT_DIR%\libcrypto-3-x64.dll" libcrypto-3-x64.dll
 
-    cd ..
+  cd ..
 
-    7z a TrinityCoreWin64VS2022.zip .\RelWithDebInfo\*
+  7z a TrinityCoreWin64VS2022.zip .\RelWithDebInfo\*
 
-    del /F /Q /S "RelWithDebInfo\*.pdb" > NUL
+  del /F /Q /S "RelWithDebInfo\*.pdb" > NUL
 
-    7z a TrinityCoreWin64VS2022NoSymbols.zip .\RelWithDebInfo\*
+  7z a TrinityCoreWin64VS2022NoSymbols.zip .\RelWithDebInfo\*
 
 test: off
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_depth: 1
 init:
 - ps: ''
 environment:
-  BOOST_ROOT: C:\Libraries\boost_1_85_0
+  BOOST_ROOT: C:\Libraries\boost_1_78_0
   MYSQL_ROOT_DIR: C:\Program Files\MySQL\MySQL Server 8.0
   OPENSSL_ROOT_DIR: C:\OpenSSL-v32-Win64
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,30 +8,31 @@ environment:
   MYSQL_ROOT_DIR: C:\Program Files\MySQL\MySQL Server 8.0
   OPENSSL_ROOT_DIR: C:\OpenSSL-v30-Win64
 
+build_script:
 - cmd: |
-  git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
+    git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
 
-  cmake -S . -B .\build -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True
+    cmake -S . -B .\build -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True
 
-  cd build
+    cd build
 
-  "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity=minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
+    "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity=minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
 
-  cd bin\RelWithDebInfo\
+    cd bin\RelWithDebInfo\
 
-  copy "%MYSQL_ROOT_DIR%\lib\libmysql.dll" libmysql.dll
+    copy "%MYSQL_ROOT_DIR%\lib\libmysql.dll" libmysql.dll
 
-  copy "%OPENSSL_ROOT_DIR%\libssl-3-x64.dll" libssl-3-x64.dll
+    copy "%OPENSSL_ROOT_DIR%\libssl-3-x64.dll" libssl-3-x64.dll
 
-  copy "%OPENSSL_ROOT_DIR%\libcrypto-3-x64.dll" libcrypto-3-x64.dll
+    copy "%OPENSSL_ROOT_DIR%\libcrypto-3-x64.dll" libcrypto-3-x64.dll
 
-  cd ..
+    cd ..
 
-  7z a TrinityCoreWin64VS2022.zip .\RelWithDebInfo\*
+    7z a TrinityCoreWin64VS2022.zip .\RelWithDebInfo\*
 
-  del /F /Q /S "RelWithDebInfo\*.pdb" > NUL
+    del /F /Q /S "RelWithDebInfo\*.pdb" > NUL
 
-  7z a TrinityCoreWin64VS2022NoSymbols.zip .\RelWithDebInfo\*
+    7z a TrinityCoreWin64VS2022NoSymbols.zip .\RelWithDebInfo\*
 
 test: off
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,50 +4,53 @@ clone_depth: 1
 init:
 - ps: ''
 environment:
-  BOOST_ROOT: C:\Libraries\boost_1_83_0
-  MYSQL_ROOT_DIR: C:\mysql-8.1.0-winx64
+  BOOST_ROOT: C:\local\boost_1_78_0
+  MYSQL_ROOT_DIR: C:\mysql-8.0.43-winx64
   OPENSSL_ROOT_DIR: C:\OpenSSL-v30-Win64
 install:
-- ps: >-
-    Write-Host "Installing MySQL Server 8.1" -ForegroundColor Cyan
+ps: >-
+  # Instalar Boost 1.78.0
+  $boostZip = "$($env:temp)\boost_1_78_0.zip"
+  Write-Host "Descargando Boost 1.78.0..." -ForegroundColor Cyan
+  (New-Object Net.WebClient).DownloadFile('https://archives.boost.io/release/1.78.0/source/boost_1_78_0.zip', $boostZip)
+  Write-Host "Descomprimiendo Boost..." -ForegroundColor Cyan
+  7z x $boostZip -o"C:\local" | Out-Null
+  Write-Host "Boost instalado en C:\local\boost_1_78_0" -ForegroundColor Cyan
 
-    Write-Host "Downloading MySQL..."
-
-    $zipPath = "$($env:temp)\mysql-8.1.0-winx64.zip"
-
-    (New-Object Net.WebClient).DownloadFile('https://cdn.mysql.com//Downloads/MySQL-8.1/mysql-8.1.0-winx64.zip', $zipPath)
-
-    Write-Host "Unpacking..."
-
-    7z x $zipPath -o"C:\" | Out-Null
-
-    Write-Host "MySQL Server 8.1 installed" -ForegroundColor Cyan
+  # Instalar MySQL Server 8.0
+  Write-Host "Installing MySQL Server 8.0" -ForegroundColor Cyan
+  Write-Host "Downloading MySQL..."
+  $zipPath = "$($env:temp)\mysql-8.0.43-winx64.zip"
+  (New-Object Net.WebClient).DownloadFile('https://cdn.mysql.com//Downloads/MySQL-8.0/mysql-8.0.43-winx64.zip', $zipPath)
+  Write-Host "Unpacking..."
+  7z x $zipPath -o"C:\" | Out-Null
+  Write-Host "MySQL Server 8.0 installed" -ForegroundColor Cyan
 
 build_script:
-- cmd: >-
-    git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
+cmd: >-
+  git config user.email "appveyor@build.bot" && git config user.name "AppVeyor"
 
-    md build && cd build
+  md build && cd build
 
-    cmake -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True -DCMAKE_CXX_FLAGS=" /DWIN32 /D_WINDOWS /W3 /GR /EHsc /WX" -DCMAKE_C_FLAGS="/DWIN32 /D_WINDOWS /W3 /WX" ..
+  cmake -G"Visual Studio 17 2022" -A x64 -DSCRIPTS=static -DTOOLS=True -DCMAKE_CXX_FLAGS=" /DWIN32 /D_WINDOWS /W3 /GR /EHsc /WX" -DCMAKE_C_FLAGS="/DWIN32 /D_WINDOWS /W3 /WX" -DCMAKE_PREFIX_PATH=%BOOST_ROOT% ..
 
-    "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
+  "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /nologo /m:2 /p:Configuration=RelWithDebInfo /p:Platform="X64" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" "TrinityCore.sln"
 
-    cd bin\RelWithDebInfo\
+  cd bin\RelWithDebInfo\
 
-    copy "%MYSQL_ROOT_DIR%\lib\libmysql.dll" libmysql.dll
+  copy "%MYSQL_ROOT_DIR%\lib\libmysql.dll" libmysql.dll
 
-    copy "%OPENSSL_ROOT_DIR%\libssl-3-x64.dll" libssl-3-x64.dll
+  copy "%OPENSSL_ROOT_DIR%\libssl-3-x64.dll" libssl-3-x64.dll
 
-    copy "%OPENSSL_ROOT_DIR%\libcrypto-3-x64.dll" libcrypto-3-x64.dll
+  copy "%OPENSSL_ROOT_DIR%\libcrypto-3-x64.dll" libcrypto-3-x64.dll
 
-    cd ..
+  cd ..
 
-    7z a TrinityCoreWin64VS2022.zip .\RelWithDebInfo\*
+  7z a TrinityCoreWin64VS2022.zip .\RelWithDebInfo\*
 
-    del /F /Q /S "RelWithDebInfo\*.pdb" > NUL
+  del /F /Q /S "RelWithDebInfo\*.pdb" > NUL
 
-    7z a TrinityCoreWin64VS2022NoSymbols.zip .\RelWithDebInfo\*
+  7z a TrinityCoreWin64VS2022NoSymbols.zip .\RelWithDebInfo\*
 
 test: off
 artifacts:

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -132,6 +132,14 @@ variables_map GetConsoleArguments(int argc, char** argv, fs::path& configFile, s
 /// Launch the Trinity server
 extern int main(int argc, char** argv)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_PROVIDER* legacy = OSSL_PROVIDER_load(nullptr, "legacy");
+    if (!legacy) {
+        printf("ERROR: OpenSSL legacy provider could not be loaded. RC4 will not be available.\n");
+    } else {
+        printf("OpenSSL legacy provider loaded successfully.\n");
+    }
+#endif
     Trinity::Impl::CurrentServerProcessHolder::_type = SERVER_PROCESS_WORLDSERVER;
     signal(SIGABRT, &Trinity::AbortHandler);
 


### PR DESCRIPTION
EN: Add OpenSSL legacy provider loading in main.cpp for RC4 support
Explicitly load and check the OpenSSL "legacy" provider at startup to ensure RC4 is available for client-server communication. This change resolves runtime issues with RC4 initialization on OpenSSL 3.x and improves compatibility with WoW clients.

ES: Se ha añadido la carga del proveedor heredado de OpenSSL en main.cpp para compatibilidad con RC4.
Se carga y comprueba explícitamente el proveedor heredado de OpenSSL al inicio para garantizar que RC4 esté disponible para la comunicación cliente-servidor. Este cambio soluciona problemas de ejecución con la inicialización de RC4 en OpenSSL 3.x y mejora la compatibilidad con los clientes de WoW.