### PR TITLE
Core/Spells: Fixed missing UNIT_DYNFLAG_DEAD flag from spell_gen_feig…

### DIFF
--- a/sql/updates/world/4.3.4/2025_12_22_00_world.sql
+++ b/sql/updates/world/4.3.4/2025_12_22_00_world.sql
@@ -1,0 +1,20 @@
+-- 2025_03_14_00_world.sql updated spell 29266 to use 
+-- `spell_gen_feign_death_all_flags_no_uninteractible`
+-- to fix issues with uninteractible dead NPCs.
+-- 
+-- For example, Lieutenant Walden (ID 34863), the very
+-- first NPC to complete the very first quest of the 
+-- Worgen starting zone, was uninteractible for non-GM 
+-- players.
+-- 
+-- However, 2025_03_15_00_world.sql then attempted to 
+-- delete the previous, non-existent entry
+-- `spell_gen_feign_death_all_flags_uninteractible`
+-- and... re-inserts it.
+-- This results in two entries for spell 29266, with 
+-- the uninteractible one wrongfully taking over.
+-- 
+-- The following resolves the conflict.
+DELETE FROM `spell_script_names` 
+      WHERE `spell_id`   = 29266 
+        AND `ScriptName` = 'spell_gen_feign_death_all_flags_uninteractible';

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -1793,6 +1793,7 @@ class spell_gen_feign_death_all_flags_uninteractible : public AuraScript
     void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         Unit* target = GetTarget();
+        target->SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
         target->SetFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
         target->SetImmuneToAll(true);
         target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT | UNIT_FLAG_NOT_SELECTABLE);
@@ -1804,6 +1805,7 @@ class spell_gen_feign_death_all_flags_uninteractible : public AuraScript
     void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         Unit* target = GetTarget();
+        target->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
         target->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
         target->SetImmuneToAll(false);
         target->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT| UNIT_FLAG_NOT_SELECTABLE);
@@ -1825,6 +1827,7 @@ class spell_gen_feign_death_all_flags_no_uninteractible : public AuraScript
     void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         Unit* target = GetTarget();
+        target->SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
         target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG2_FEIGN_DEATH);
         target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
         target->SetImmuneToAll(true);
@@ -1836,6 +1839,7 @@ class spell_gen_feign_death_all_flags_no_uninteractible : public AuraScript
     void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         Unit* target = GetTarget();
+        target->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
         target->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG2_FEIGN_DEATH);
         target->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES_FROM_CHAT_TEXT);
         target->SetImmuneToAll(false);


### PR DESCRIPTION
…n_death_all_flags_uninteractible.

Also fixed a duplicate entry for spell 29266.

This is a fix I made while testing a few months ago but didn't commit until now.