### PR TITLE
Packets/Party: fix GUID byte handling in role packets

### DIFF
--- a/src/server/game/Server/Packets/PartyPackets.cpp
+++ b/src/server/game/Server/Packets/PartyPackets.cpp
@@ -569,7 +569,7 @@ void WorldPackets::Party::SetRole::Read()
     _worldPacket.ReadByteSeq(ChangedUnit[3]);
     _worldPacket.ReadByteSeq(ChangedUnit[0]);
     _worldPacket.ReadByteSeq(ChangedUnit[5]);
-    _worldPacket.ReadByteSeq(ChangedUnit[3]);
+    _worldPacket.ReadByteSeq(ChangedUnit[2]);
     _worldPacket.ReadByteSeq(ChangedUnit[7]);
 }
 
@@ -600,7 +600,7 @@ WorldPacket const* WorldPackets::Party::RoleChangedInform::Write()
 
     _worldPacket << uint32(NewRole);
 
-    _worldPacket.WriteByteSeq(ChangedUnit[6]);
+    _worldPacket.WriteByteSeq(ChangedUnit[5]);
     _worldPacket.WriteByteSeq(ChangedUnit[2]);
     _worldPacket.WriteByteSeq(From[0]);
     _worldPacket.WriteByteSeq(From[4]);


### PR DESCRIPTION
**Changes proposed**:
Fix corrupted GUID handling in CMSG_SET_ROLE and SMSG_ROLE_CHANGED_INFORM.

During the packet class conversion, one GUID byte was read/written twice while another byte was skipped:
- SetRole::Read read ChangedUnit[3] twice and never read ChangedUnit[2].
- RoleChangedInform::Write wrote ChangedUnit[6] twice and never wrote ChangedUnit[5].

As a result, role selection responses could resolve to an invalid group member GUID, causing role updates to fail.

This restores the GUID byte order used by the previous raw packet handlers.


**Tests performed**: (Does it build, tested in-game, etc)
build
Tested ingame:
- created a party/raid
- started a role poll
- selected Tank/Healer/Damage roles
- role selection is now applied and propagated correctly

** 
This regression was introduced by commit 056248cef117c49e2c765eb8a7c86a1f5df279d8
("Core/Packets: converted CMSG_SET_ROLE and SMSG_ROLE_CHANGED_INFORM to packet class").

During the packet class conversion, one ChangedUnit GUID byte was duplicated while another one was skipped:
- SetRole::Read reads ChangedUnit[3] twice and never reads ChangedUnit[2].
- RoleChangedInform::Write writes ChangedUnit[6] twice and never writes ChangedUnit[5].

This causes CMSG_SET_ROLE to decode a corrupted ChangedUnit GUID, so Group::SetLfgRoles cannot resolve the selected group member and the selected role is not applied.

