### PR TITLE
Core/Spells: Fix player cast cancellation on movement

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -4157,7 +4157,8 @@ void Spell::update(uint32 difftime)
         // if charmed by creature, trust the AI not to cheat and allow the cast to proceed
         // @todo this is a hack, "creature" movesplines don't differentiate turning/moving right now
         // however, checking what type of movement the spline is for every single spline would be really expensive
-        if (!m_caster->ToUnit()->IsControlledByPlayer())
+        Unit* unitCaster = m_caster->ToUnit();
+        if (!unitCaster->GetCharmerGUID().IsCreature() && (!unitCaster->IsControlledByPlayer() || unitCaster->GetTypeId() == TYPEID_PLAYER))
             cancel();
     }
 


### PR DESCRIPTION
**Changes proposed**:

Fixes movement-based cast cancellation so player casters correctly have their active casts interrupted when moving.

**Issues addressed**: Fixes #

`Spell::update()` checks whether a unit moved while casting a spell that should not be cast while moving.  
The previous condition only cancelled the spell when the caster was **not** controlled by a player:

`
if (!m_caster->ToUnit()->IsControlledByPlayer())
    cancel();
`

This meant normal player casters could move during casts without the spell being cancelled by this check.

The caster is now stored as unitCaster, and the cancellation condition explicitly includes real player units:

`
if (!unitCaster->GetCharmerGUID().IsCreature() &&
    (!unitCaster->IsControlledByPlayer() || unitCaster->GetTypeId() == TYPEID_PLAYER))
    cancel();
`

This keeps the existing creature-charmer exception intact, while ensuring player characters are still subject to normal movement cast interruption.

**Tests performed**: (Does it build, tested in-game, etc)
Build
Movement cancel now correct the cast.
