### PR TITLE
Fix build with Boost 1.9x, Stormlib crash

### DIFF
--- a/dep/StormLib/CMakeLists.txt
+++ b/dep/StormLib/CMakeLists.txt
@@ -277,6 +277,10 @@ target_include_directories(storm
     ${CMAKE_SOURCE_DIR}/dep/zlib
     ${CMAKE_SOURCE_DIR}/dep/bzip2)
 
+target_compile_definitions(storm
+  PUBLIC
+    __STORMLIB_NO_STATIC_LINK__)
+
 target_link_libraries(storm
   PRIVATE
     trinity-dependency-interface

--- a/dep/StormLib/src/SFileFindFile.cpp
+++ b/dep/StormLib/src/SFileFindFile.cpp
@@ -416,7 +416,7 @@ HANDLE WINAPI SFileFindFirstFile(HANDLE hMpq, const char * szMask, SFILE_FIND_DA
     if(dwErrCode == ERROR_SUCCESS)
     {
         memset(hs, 0, sizeof(TMPQSearch));
-        strcpy(hs->szSearchMask, szMask);
+        memcpy(hs->szSearchMask, szMask, strlen(szMask) + 1);
         hs->dwFlagMask = MPQ_FILE_EXISTS;
         hs->ha = ha;
 

--- a/dep/boost/CMakeLists.txt
+++ b/dep/boost/CMakeLists.txt
@@ -47,7 +47,6 @@ endif()
 find_package(Boost ${BOOST_REQUIRED_VERSION}
   REQUIRED
   COMPONENTS 
-    system
     filesystem
     thread
     program_options


### PR DESCRIPTION
**Changes proposed**:

- Allow building with Boost 1.9x > https://github.com/TrinityCore/TrinityCore/commit/c87a004a1688f5dfe463493fbcd47027ea1dcf2e
- Fix Stormlib compilation issues
- Fix crash related to `SFileFindFirstFile `in mapextractor

**Issues addressed**: Fixes #

**Tests performed**: (Does it build, tested in-game, etc):
- Build as RelWithDeb in Visual Studio 2026.
- Ran mapextractor.exe > [pastebin logs](https://pastebin.com/raw/PbTzTiYj)

**Known issues and TODO list**:
- Verify compatibility with **Linux/Unix/Etc**
