### PR TITLE
Core/Pets: Correct SMSG_PET_SLOT_UPDATED

### DIFF
--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -949,10 +949,10 @@ void WorldSession::SendPetSlotUpdated(int32 petNumberA, int32 petSlotA, int32 pe
 {
     WorldPacket data(SMSG_PET_SLOT_UPDATED, 4 + 4 + 4 + 4);
 
+    data << int32(petSlotA);
     data << uint32(petNumberA);
-    data << uint32(petSlotA);
     data << uint32(petNumberB);
-    data << uint32(petSlotB);
+    data << int32(petSlotB);
 
     SendPacket(&data);
 }


### PR DESCRIPTION
Large pet GUIDs can cause a client crash when moving a pet from the stable to the call list or vice versa.

After researching and reverse-engineering the handling of the incoming SMSG_PET_SLOT_UPDATED packet in the client, I determined that the field order was incorrect.

With the previous field order, the client interpreted the pet GUID as the slot index, which could result in an out-of-bounds access when the GUID was too large.


**Tests performed**: (Does it build, tested in-game, etc)
- Successfully built.
- Tested in-game by moving pets from the stable to the call list and vice versa.
- The client no longer crashed.
