### PR TITLE
Core/Gossip: Fix trainer lookup for inherited default options

### DIFF
--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -9182,6 +9182,17 @@ uint32 ObjectMgr::GetCreatureTrainerForGossipOption(uint32 creatureId, uint32 go
     if (itr != _creatureDefaultTrainers.end())
         return itr->second;
 
+    if (gossipMenuId)
+    {
+        GossipMenuItemsMapBounds gossipMenuItems = GetGossipMenuItemsMapBounds(gossipMenuId);
+        if (gossipMenuItems.first == gossipMenuItems.second)
+        {
+            itr = _creatureDefaultTrainers.find(std::make_tuple(creatureId, 0, gossipOptionId));
+            if (itr != _creatureDefaultTrainers.end())
+                return itr->second;
+        }
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
An existing mismatch was found between default gossip option inheritance and trainer resolution. PrepareGossipMenu inherits options from menu 0 when the selected creature menu has no options, but GetCreatureTrainerForGossipOption only searches using the selected creature menu ID. Fix appends logic like this:

1. Try the selected menu:
   (CreatureID, selected MenuID, OptionID)

2. If no trainer was found:
   Check whether that selected menu has zero DB options

3. Only if it has zero options:
   Retry the inherited default option:
   (CreatureID, 0, OptionID)

**Changes proposed**:

- Fix trainer lookup for inherited default options

**Tests performed**: (Does it build, tested in-game, etc)
Build,
Worked In-game

**Steps to reproduce**:

1. Create a Worgen rogue
2. Accept quest 14272, Eviscerate
3. Speak with Loren the Fence (35871)
4. Select "Train me!"
5. Before the fix, no trainer window opens
6. After the fix, trainer 17 opens and offers Eviscerate (2098)